### PR TITLE
remove flex from button; add padding to text button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -57,7 +57,6 @@ export interface ButtonProps<C> extends MuiButtonProps {
 const ButtonRoot = styled(MuiButton)(({ theme, variant }) => ({
   /** these styles apply to buttons universally */
   display: 'flex',
-  flex: 1,
   borderRadius: 8,
   alignItems: 'center',
   boxShadow: 'none',
@@ -104,7 +103,7 @@ const ButtonRoot = styled(MuiButton)(({ theme, variant }) => ({
   ...(variant === 'text' && {
     /** @TODO confirm that text buttons don't follow the same min width rules */
     minWidth: 'min-content',
-    padding: 0,
+    padding: '0px 16px',
   }),
 }));
 


### PR DESCRIPTION
Removes `flex: 1` from the `Button` component and adds horizontal padding for text buttons. Screenshot below is how it should look in izakaya:

![Screen Shot 2022-05-20 at 11 41 46 AM](https://user-images.githubusercontent.com/67885346/169592236-065aede3-6989-48fd-879e-680f2fcd92a7.png)
 