### PR TITLE
[ROK-712] inline notification

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -194,7 +194,7 @@ interface InlineNotificationProps extends BoxProps {
      *
      * @default false
      */
-    startIcon?: boolean;
+    showStartIcon?: boolean;
     /**
      * @optional function to do some kind of action
      */
@@ -207,6 +207,6 @@ interface InlineNotificationProps extends BoxProps {
      *  */
     actionLabel?: string;
 }
-declare const InlineNotification: ({ children, variant, onClose, startIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
+declare const InlineNotification: ({ children, variant, onClose, showStartIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
 
 export { Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -10,6 +10,7 @@ import { CardContentProps as CardContentProps$1 } from '@mui/material/CardConten
 import { TypographyProps as TypographyProps$1 } from '@mui/material/Typography';
 import { ImageListItemProps } from '@mui/material/ImageListItem';
 import { ImageListProps } from '@mui/material/ImageList';
+import { TextFieldProps as TextFieldProps$1 } from '@mui/material/TextField';
 
 interface BoxProps extends BoxProps$1 {
 }
@@ -152,4 +153,60 @@ interface ImageGridProps extends ImageListProps {
 }
 declare const ImageGrid: ({ children, ...props }: ImageGridProps) => JSX.Element;
 
-export { Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, LineItem, LineItemProps, Typography, TypographyProps, fontWeights };
+declare type SuggestedActionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
+interface SuggestedActionProps {
+    variant: SuggestedActionVariant;
+    description: React$1.ReactNode;
+    onClickMenu: () => void;
+    dueDate?: string;
+    cta: string;
+    ctaAction: () => void;
+    secondaryCta?: string;
+    secondaryCtaAction?: () => void;
+}
+declare const SuggestedAction: ({ variant, description, onClickMenu, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, }: SuggestedActionProps) => JSX.Element;
+
+declare type Mask = 'money' | 'moneyWithCents' | 'ssn' | 'lastFourSsn' | 'bankNumber' | 'phone' | 'percent' | 'taxId' | 'year' | 'default' | 'search';
+
+declare type TextFieldProps = {
+    mask: Mask;
+    value?: string;
+} & TextFieldProps$1;
+declare const TextField: ({ mask, value, onChange, ...otherProps }: TextFieldProps) => JSX.Element;
+
+declare const StatefulTextField: (props: TextFieldProps) => JSX.Element;
+
+declare enum NotificationVariant {
+    info = "info",
+    warning = "warning",
+    error = "error"
+}
+interface InlineNotificationProps extends BoxProps {
+    /**
+     * Inline notifications are constrained to `info`, `warning`, or `error`.
+     * Since the default value is `info`, the default component will have styles
+     * related to that variant.
+     * @default `info`
+     */
+    variant?: NotificationVariant;
+    onClose?: (args?: any) => void;
+    /**
+     *
+     * @default false
+     */
+    startIcon?: boolean;
+    /**
+     * @optional function to do some kind of action
+     */
+    action?: (args?: any) => void;
+    /**
+     * the text of the actual button. If an `action` is provided without an `actionLabel`,
+     * a standalone arrow icon will appear as the CTA
+     *
+     * @default undefined
+     *  */
+    actionLabel?: string;
+}
+declare const InlineNotification: ({ children, variant, onClose, startIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
+
+export { Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };

--- a/src/components/InlineNotification/InlineNotification.stories.mdx
+++ b/src/components/InlineNotification/InlineNotification.stories.mdx
@@ -105,7 +105,7 @@ the component defaults to `info`.
 #### Info:
 
 > The default variant of an `InlineNotification`.
-It has a header color of `primary.500`, and if `startIcon` is `true`, shows the
+It has a header color of `blue.500`, and if `showStartIcon` is `true`, shows the
 [**`InfoOutlined`**](https://mui.com/material-ui/material-icons/?query=info&theme=Outlined&selected=InfoOutlined)🔗
 icon at the beginning of the component.
 
@@ -117,7 +117,7 @@ icon at the beginning of the component.
     args={{
       variant: 'info',
       children: `This is an informational inline notification`,
-      startIcon: true,
+      showStartIcon: true,
       actionLabel: undefined,
     }}
   >
@@ -128,7 +128,7 @@ icon at the beginning of the component.
 #### Warning:
 
 > The default variant of an `InlineNotification`.
-It has a header color of `yellow.500`, and if `startIcon` is `true`, shows the
+It has a header color of `yellow.500`, and if `showStartIcon` is `true`, shows the
 [**`WarningAmber`**](https://mui.com/material-ui/material-icons/?query=warning&selected=WarningAmber)🔗
 icon at the beginning of the component.
 
@@ -140,7 +140,7 @@ icon at the beginning of the component.
     args={{
       variant: 'warning',
       children: `This is a warning inline notification`,
-      startIcon: true,
+      showStartIcon: true,
       actionLabel: undefined,
     }}
   >
@@ -151,7 +151,7 @@ icon at the beginning of the component.
 #### Error:
 
 > The default variant of an `InlineNotification`.
-It has a header color of `yellow.500`, and if `startIcon` is `true`, shows the
+It has a header color of `red.500`, and if `showStartIcon` is `true`, shows the
 [**`CancelOutlined`**](https://mui.com/material-ui/material-icons/?query=cancel&theme=Outlined&selected=CancelOutlined)🔗
 icon at the beginning of the component.
 
@@ -163,7 +163,7 @@ icon at the beginning of the component.
     args={{
       variant: 'error',
       children: `This is a error inline notification`,
-      startIcon: true,
+      showStartIcon: true,
       actionLabel: undefined,
     }}
   >
@@ -177,9 +177,9 @@ icon at the beginning of the component.
 
 ### Optional props
 
-#### `startIcon`
+#### `showStartIcon`
 
-By default, an `InlineNotification` does not have a `startIcon`, regardless of the variant. If, however,
+By default, an `InlineNotification` does not have a `showStartIcon`, regardless of the variant. If, however,
 the prop is passed as `true`, then an icon corresponding to the variant will appear at the left (see above).
 
 #### `onClose`

--- a/src/components/InlineNotification/InlineNotification.stories.mdx
+++ b/src/components/InlineNotification/InlineNotification.stories.mdx
@@ -1,0 +1,296 @@
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import { withDesign } from 'storybook-addon-designs';
+
+import InlineNotification from './InlineNotification';
+import Box from '../Box';
+import Typography from '../Typography';
+
+export const argTypes = {
+  variant: {
+    control: { type: "select" },
+    options: ["info", "warning", "error"],
+    defaultValue: "info",
+    type: { required: false },
+    table: {
+      type: {
+        summary: '"info" | "warning" | "error"',
+      },
+    },
+  },
+  startIcon: {
+    control: { type: 'boolean' },
+    defaultValue: false,
+    table: {
+      type: {
+        summary: 'true | false',
+        defaultValue: false,
+      },
+    },
+  },
+  onClose: {
+    control: { type: 'radio' },
+    options: ['show close button', 'hide close button'],
+    description: 'Accepts a function that is called when the close icon is clicked',
+    defaultValue: 'show close button',
+    mapping: {
+      'show close button': () => { },
+      'hide close button': null,
+    }
+  },
+  action: {
+    control: { type: 'radio' },
+    options: ['with action', 'without action'],
+    defaultValue: 'without action',
+    description: 'Accepts a function that renders an optional action button',
+    mapping: {
+      'with action': () => { },
+      'without action': undefined,
+    }
+  },
+  actionLabel: {
+    defaultValue: 'Button Label',
+    control: {
+      type: 'text',
+    },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  children: {
+    type: { required: true },
+    defaultValue: 'This is an inline notification with some text',
+    control: {
+      type: 'text',
+    },
+    table: {
+      type: { summary: 'ReactNode' },
+    },
+  },
+};
+
+<Meta
+  title="Molecules/InlineNotification"
+  component={InlineNotification}
+  argTypes={argTypes}
+  parameters={{
+    layout: 'padded',
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/xfmzo1QWKiFbf2tx7Q2NUa/HAJIMARI-Design-System?node-id=747%3A7813',
+    },
+  }}
+/>
+
+export const InlineNotificationTemplate = (args) => <InlineNotification {...args} />;
+
+# InlineNotification
+
+`InlineNotification`s are nondisruptive and confined to a specific area in the UI. They display
+both task-generated and system-generated messages and persist until they are dismissed by
+the user or the notification is resolved. They are frequently used in conjunction with
+field-level messages for errors in forms or other input areas.
+
+<br />
+
+## Usage and examples
+
+Available variants include: <b>`info`</b>, <b>`warning`</b>, <b>`filled`</b>, and <b>`error`</b>.
+Each variant maps to a particular `startIcon` and top border color. If no variant is passed in,
+the component defaults to `info`.
+
+<br />
+
+### Variants
+
+#### Info:
+
+> The default variant of an `InlineNotification`.
+It has a header color of `primary.500`, and if `startIcon` is `true`, shows the
+[**`InfoOutlined`**](https://mui.com/material-ui/material-icons/?query=info&theme=Outlined&selected=InfoOutlined)🔗
+icon at the beginning of the component.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Info"
+    component={InlineNotification}
+    args={{
+      variant: 'info',
+      children: `This is an informational inline notification`,
+      startIcon: true,
+      actionLabel: undefined,
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### Warning:
+
+> The default variant of an `InlineNotification`.
+It has a header color of `yellow.500`, and if `startIcon` is `true`, shows the
+[**`WarningAmber`**](https://mui.com/material-ui/material-icons/?query=warning&selected=WarningAmber)🔗
+icon at the beginning of the component.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Warning"
+    component={InlineNotification}
+    args={{
+      variant: 'warning',
+      children: `This is a warning inline notification`,
+      startIcon: true,
+      actionLabel: undefined,
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### Error:
+
+> The default variant of an `InlineNotification`.
+It has a header color of `yellow.500`, and if `startIcon` is `true`, shows the
+[**`CancelOutlined`**](https://mui.com/material-ui/material-icons/?query=cancel&theme=Outlined&selected=CancelOutlined)🔗
+icon at the beginning of the component.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Error"
+    component={InlineNotification}
+    args={{
+      variant: 'error',
+      children: `This is a error inline notification`,
+      startIcon: true,
+      actionLabel: undefined,
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+---
+
+<br />
+
+### Optional props
+
+#### `startIcon`
+
+By default, an `InlineNotification` does not have a `startIcon`, regardless of the variant. If, however,
+the prop is passed as `true`, then an icon corresponding to the variant will appear at the left (see above).
+
+#### `onClose`
+
+By default, if no `onClose` function is provided, then we do not render a close icon
+
+<Canvas>
+  <Story
+    height="100px"
+    name="With onClose"
+    args={{
+      children: 'This is an inline notification with an onClose',
+      actionLabel: undefined,
+      onClose: () => {},
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Without onClose"
+    args={{
+      children: 'This is an inline notification without an onClose',
+      startIcon: true,
+      actionLabel: undefined,
+      onClose: undefined,
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### `action` and `actionLabel`
+
+An `InlineNotification` accepts an `action` and `actionLabel`, which will render a `text` button
+at the end of the component, just before the close button (if an `onClose` is provided).
+
+If an `actionLabel` is provided without an `action`, the button will not be rendered.
+
+If an `action` is provided without an `actionLabel` (the reverse), then the button will be rendered
+with only the arrow icon.
+
+**Best Practice**:
+The optional button is adjacent to the title and body content. On mobile screens the action button wraps
+under the body content. This button should allow users to take further action on the notification.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="With action"
+    component={InlineNotification}
+    args={{
+      children: `This is an inline notification with an action`,
+      startIcon: true,
+      action: () => {},
+      actionLabel: 'Action',
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Without action"
+    component={InlineNotification}
+    args={{
+      children: `This is an inline notification without an action`,
+      action: undefined,
+      actionLabel: 'Action',
+    }}
+  >
+    {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+---
+
+<br />
+
+### Sandbox
+
+<Canvas>
+  <Story
+    name="Sandbox"
+    height="100px"
+  >
+  {InlineNotificationTemplate.bind()}
+  </Story>
+</Canvas>
+
+<ArgsTable of={InlineNotification} story="Sandbox" />
+
+---
+
+<br />
+
+# Additional Notes
+
+#### Sizing
+The width of inline notifications varies based on content and layout. They can expand to
+the fill the container or content area they relate to. Their height is based on the content length,
+which should not exceed two lines of text. If it exceeds more than two lines, the text should
+stay centered.
+
+<br />
+
+#### Placement
+Inline notifications appear near their related items. They can expand to fill the width of the
+container or content area they are in and should align to the grid columns.

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -31,7 +31,7 @@ export interface InlineNotificationProps extends BoxProps {
    * 
    * @default false
    */
-  startIcon?: boolean;
+  showStartIcon?: boolean;
   /**
    * @optional function to do some kind of action
    */
@@ -107,7 +107,7 @@ const InlineNotification = ({
   children,
   variant = NotificationVariant.info,
   onClose,
-  startIcon,
+  showStartIcon,
   action,
   actionLabel = '',
   ...props
@@ -116,7 +116,7 @@ const InlineNotification = ({
     <TopHighlightRoot variant={variant} />
     <NotificationContent>
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        {startIcon &&
+        {showStartIcon &&
           <Box sx={{ mr: 1, mt: 0.5 }}>
             {variantIcons[variant]}
           </Box>
@@ -143,7 +143,7 @@ const InlineNotification = ({
       <ActionButton
         label={actionLabel}
         sx={{
-          ml: startIcon ? 4 : 0,
+          ml: showStartIcon ? 4 : 0,
           mt: -1.5,
           display: { sm: 'none' },
         }}

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
+import { experimental_sx as e_sx, SxProps } from '@mui/system';
+
+import Box, { BoxProps } from '../Box/Box';
+import Typography from '../Typography';
+import IconButton from '../IconButton';
+import Button from '../Button/Button';
+import styled from '../../theme/styled';
+
+export enum NotificationVariant {
+  info = 'info',
+  warning = 'warning',
+  error = 'error'
+}
+
+export interface InlineNotificationProps extends BoxProps {
+  /**
+   * Inline notifications are constrained to `info`, `warning`, or `error`.
+   * Since the default value is `info`, the default component will have styles
+   * related to that variant.
+   * @default `info`
+   */
+  variant?: NotificationVariant;
+  onClose?: (args?: any) => void;
+  /**
+   * 
+   * @default false
+   */
+  startIcon?: boolean;
+  /**
+   * @optional function to do some kind of action
+   */
+  action?: (args?: any) => void;
+  /**
+   * the text of the actual button. If an `action` is provided without an `actionLabel`,
+   * a standalone arrow icon will appear as the CTA
+   * 
+   * @default undefined
+   *  */
+  actionLabel?: string;
+}
+
+const NotificationRoot = styled(Box, {
+  name: 'InlineNotificationRoot',
+})<InlineNotificationProps>(e_sx({
+  borderRadius: 8,
+  border: '1px solid',
+  borderColor: 'greyscale.500',
+  backgroundColor: 'greyscale.100',
+  borderTop: 'none',
+  paddingBottom: '0.5rem',
+}));
+
+const TopHighlightRoot = styled('div', {
+  name: 'TopHighlightRoot',
+})<InlineNotificationProps>(({ theme, variant }) => e_sx(({
+  borderTopLeftRadius: 8,
+  borderTopRightRadius: 8,
+  alignSelf: 'flex-start',
+  paddingTop: 0.25,
+  borderTop: '4px solid',
+  /** default variant is "info" */
+  borderTopColor: 'blue.500',
+  ...(variant === 'warning' && {
+    borderTopColor: 'yellow.500',
+  }),
+  ...(variant === 'error' && {
+    borderTopColor: 'red.500',
+  }),
+})));
+
+const NotificationContent = styled('div', { name: 'NotificationContent' })({
+  paddingTop: 8,
+  paddingLeft: 16,
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+type ActionButtonProps = {
+  label: string;
+  sx?: SxProps;
+};
+
+const ActionButton = ({ label, sx }: ActionButtonProps): JSX.Element => (
+  <Button
+    variant="text"
+    color="blue"
+    endIcon={<ArrowForwardIcon />}
+    sx={sx}
+  >
+    {label}
+  </Button>
+);
+
+const variantIcons: Record<NotificationVariant, React.ReactNode> = {
+  [NotificationVariant.info]: <InfoOutlinedIcon sx={{ fontSize: 24 }} />,
+  [NotificationVariant.warning]: <WarningAmberOutlinedIcon sx={{ fontSize: 24 }} />,
+  [NotificationVariant.error]: <CancelOutlinedIcon sx={{ fontSize: 24 }} />,
+};
+
+const InlineNotification = ({
+  children,
+  variant = NotificationVariant.info,
+  onClose,
+  startIcon,
+  action,
+  actionLabel = '',
+  ...props
+}: InlineNotificationProps): JSX.Element => (
+  <NotificationRoot {...props}>
+    <TopHighlightRoot variant={variant} />
+    <NotificationContent>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        {startIcon &&
+          <Box sx={{ mr: 1, mt: 0.5 }}>
+            {variantIcons[variant]}
+          </Box>
+        }
+        <Typography variant="p3" weight="medium">
+          {children}
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex' }}>
+        {action &&
+          <ActionButton
+            label={actionLabel}
+            sx={{ display: { xs: 'none', sm: 'flex' }}}
+          />
+        }
+        {onClose &&
+          <IconButton onClick={onClose} sx={{ mr: 1 }}>
+            <CloseIcon sx={{ fontSize: 24 }} />
+          </IconButton>
+        }
+      </Box>
+    </NotificationContent>
+    {action &&
+      <ActionButton
+        label={actionLabel}
+        sx={{
+          ml: startIcon ? 4 : 0,
+          mt: -1.5,
+          display: { sm: 'none' },
+        }}
+      />
+    }
+  </NotificationRoot>
+);
+
+export default InlineNotification;

--- a/src/components/InlineNotification/index.ts
+++ b/src/components/InlineNotification/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InlineNotification';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -36,3 +36,6 @@ export * from './SuggestedAction/SuggestedAction';
 
 export { default as TextField } from './TextField';
 export * from './TextField/TextField';
+
+export { default as InlineNotification } from './InlineNotification';
+export * from './InlineNotification/InlineNotification';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   InformationCard,
   ImageGridItem,
   ImageGrid,
+  InlineNotification,
 } from './components';
 export * from '@mui/material';
 
@@ -54,4 +55,5 @@ export {
   InformationCard,
   ImageGridItem,
   ImageGrid,
+  InlineNotification,
 };


### PR DESCRIPTION
#### Description:
`InlineNotification` component for use across our web app! it currently accepts `info`, `warning`, or `error` variants. we can expand those in the future if we need to, but it's cleaner to stay within these parameters when we use this component.

#### Figma:
https://www.figma.com/file/xfmzo1QWKiFbf2tx7Q2NUa/HAJIMARI-Design-System?node-id=747%3A7813

#### Screenshots:
<img width="1672" alt="Screen Shot 2022-05-27 at 6 29 16 PM" src="https://user-images.githubusercontent.com/9397381/170804745-435f88d0-0378-4f2e-b2b9-e9035832ed9f.png">

#### JIRA:
https://gethearth.atlassian.net/browse/ROK-712