### PR TITLE
banner

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -209,4 +209,55 @@ interface InlineNotificationProps extends BoxProps {
 }
 declare const InlineNotification: ({ children, variant, onClose, showStartIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
 
-export { Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };
+interface BannerProps extends BoxProps {
+    /**
+     * the bolded title at the top of the banner
+     *
+     * @optional
+     * */
+    title?: string;
+    /** the description within the banner; the only required prop */
+    description: string;
+    /**
+     * determines whether the `InfoOutlinedIcon` appears to the left of the title
+     *
+     * @default false
+    */
+    showStartIcon?: boolean;
+    /**
+     * if defined, renders a `CloseIcon` at the top right of the banner, which
+     * will call the function passed to `onClose` on click
+     *
+     * @optional
+     */
+    onClose?: (args?: any) => void;
+    /**
+     * if defined in conjunction with `primaryActionLabel`, renders a primary
+     * `Button` for a primary action
+     *
+     * @optional
+     */
+    primaryAction?: (args?: any) => void;
+    /**
+     * `Button` label for the primary action
+     *
+     * @optional
+     */
+    primaryActionLabel?: string;
+    /**
+     * if defined in conjunction with `secondaryActionLabel`, renders a text
+     * `Button` for a secondary action
+     *
+     * @optional
+     */
+    secondaryAction?: (args?: any) => void;
+    /**
+     * `Button` label for the secondary action
+     *
+     * @optional
+     */
+    secondaryActionLabel?: string;
+}
+declare const Banner: ({ title, description, showStartIcon, onClose, primaryAction, primaryActionLabel, secondaryAction, secondaryActionLabel, }: BannerProps) => JSX.Element;
+
+export { Banner, BannerProps, Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };

--- a/src/components/Banner/Banner.stories.mdx
+++ b/src/components/Banner/Banner.stories.mdx
@@ -1,0 +1,232 @@
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import { withDesign } from 'storybook-addon-designs';
+
+import Banner from './Banner';
+import Typography from '../Typography';
+
+export const defaultDescription = 
+  'This is the banner description. Banners remain until dismissed by user ' +
+  'or if the state that caused the banner is resolved. This can be a longer ' +
+  'description if needed.';
+
+export const argTypes = {
+  title: {
+    defaultValue: 'This is the banner title',
+    control: {
+      type: 'text',
+    },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'null' },
+    },
+  },
+  description: {
+    type: { required: true },
+    defaultValue: defaultDescription,
+    control: {
+      type: 'text',
+    },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  showStartIcon: {
+    description: 'Determines whether the info icon appears to the left of the title',
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+    defaultValue: false,
+  },
+  onClose: {
+    control: { type: 'boolean' },
+    defaultValue: true,
+    options: ['true', 'false'],
+    mapping: {
+      'true': () => { },
+      'false': undefined,
+    }
+  },
+  primaryAction: {
+    description: 'Accepts a function that renders the primary action button',
+    table: {
+      type: { summary: 'function' },
+    },
+    control: { type: 'boolean' },
+    defaultValue: true,
+    options: ['true', 'false'],
+    mapping: {
+      'true': () => null,
+      'false': undefined,
+    },
+  },
+  primaryActionLabel: {
+    defaultValue: 'Primary Action',
+    control: {
+      type: 'text',
+    },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  secondaryAction: {
+    description: 'Accepts a function that renders the secondary action button',
+    table: {
+      type: { summary: 'function' },
+    },
+    control: { type: 'boolean' },
+    defaultValue: true,
+    options: ['true', 'false'],
+    mapping: {
+      'true': () => { },
+      'false': undefined,
+    },
+  },
+  secondaryActionLabel: {
+    defaultValue: 'Secondary Action',
+    control: {
+      type: 'text',
+    },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+};
+
+<Meta
+  title="Molecules/Banner"
+  component={Banner}
+  argTypes={argTypes}
+  parameters={{
+    layout: 'padded',
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/xfmzo1QWKiFbf2tx7Q2NUa/HAJIMARI-Design-System?node-id=727%3A7347',
+    },
+  }}
+/>
+
+export const BannerTemplate = (args) => <Banner {...args} />;
+
+# Banner
+
+`Banner`s take over the top of an interface to show general notifications for the product or system,
+not a specific task. They persist until they are dismissed by the user (if dismissible). Banners
+can include a ghost button or link. Depending on the message, the user resolving a product or
+system issue (for example, updating necessary account information), may also dismiss the banner.
+Banners may also persist across multiple sessions.
+
+<br />
+
+## Usage and examples
+
+#### Basic:
+
+At a minimum, a `Banner` requires a `description`. All other props are optional.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Basic"
+    component={Banner}
+    args={{
+      description: defaultDescription,
+      title: undefined,
+      primaryAction: undefined,
+      primaryActionLabel: undefined,
+      secondaryAction: undefined,
+      secondaryActionLabel: undefined,
+      onClose: false,
+    }}
+  >
+    {BannerTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### Without actions:
+
+A `Banner` accepts an optional `title`, as well a `showStartIcon` boolean that controls whether an
+[`InfoOutlinedIcon`](https://mui.com/material-ui/material-icons/?query=info&theme=Outlined&selected=InfoOutlined)
+appears next to the `title`.
+
+
+It also accepts an `onClose` function that will render a
+[`CloseIcon`](https://mui.com/material-ui/material-icons/?query=close&selected=Close)
+at the top right of the `Banner` that the user can click to dismiss or take other actions.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="Without actions"
+    component={Banner}
+    args={{
+      title: 'This is a banner title',
+      description: defaultDescription,
+      showStartIcon: true,
+      primaryAction: undefined,
+      primaryActionLabel: undefined,
+      secondaryAction: undefined,
+      secondaryActionLabel: undefined,
+      showStartIcon: true,
+    }}
+  >
+    {BannerTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### With actions:
+
+> **NOTE**: There is currently an [open issue](https://github.com/storybookjs/storybook/issues/17701)
+> about a bug in `storybook` that is causing functions passed into a component after the first
+> to appear as `function noRefCheck() {}`.
+
+`Banner`s can have optional *primary* and *secondary* action buttons that correspond to the
+`primaryAction` / `primaryActionLabel` and `secondaryAction` / `secondaryActionLabel` props
+respectively. For either button, both the action function and label must be passed in to `Banner`.
+If only one of a pair is passed in, that button will not appear.
+
+<Canvas>
+  <Story
+    height="100px"
+    name="With actions"
+    component={Banner}
+    args={{
+      title: 'This is a banner title',
+      description: defaultDescription,
+      showStartIcon: true,
+    }}
+  >
+    {BannerTemplate.bind()}
+  </Story>
+</Canvas>
+
+---
+
+<br />
+
+### Sandbox
+
+<Canvas>
+  <Story
+    name="Sandbox"
+    height="100px"
+  >
+    {BannerTemplate.bind()}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Banner} story="Sandbox" />
+
+---
+<br />
+
+# Additional Notes
+
+- Banners should be placed at the top of the content area they relate to.
+- Do not cover other content with a banner notification.
+- Place system-wide messages directly below the main header or navigation bar.
+- Banners are not sticky and should scroll with the other content on the page.
+- Only show one banner at a time. 
+
+<br />

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,0 +1,150 @@
+import { experimental_sx as e_sx, SxProps } from '@mui/system';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import CloseIcon from '@mui/icons-material/Close';
+
+import Box, { BoxProps } from '../Box/Box';
+import Typography from '../Typography';
+import IconButton from '../IconButton';
+import Button from '../Button';
+import styled from '../../theme/styled';
+
+export interface BannerProps extends BoxProps {
+  /**
+   * the bolded title at the top of the banner
+   * 
+   * @optional
+   * */
+  title?: string;
+  /** the description within the banner; the only required prop */
+  description: string;
+  /**
+   * determines whether the `InfoOutlinedIcon` appears to the left of the title
+   * 
+   * @default false
+  */
+  showStartIcon?: boolean;
+  /**
+   * if defined, renders a `CloseIcon` at the top right of the banner, which
+   * will call the function passed to `onClose` on click
+   * 
+   * @optional
+   */
+  onClose?: (args?: any) => void;
+  /**
+   * if defined in conjunction with `primaryActionLabel`, renders a primary
+   * `Button` for a primary action
+   * 
+   * @optional
+   */
+  primaryAction?: (args?: any) => void;
+  /**
+   * `Button` label for the primary action
+   * 
+   * @optional
+   */
+  primaryActionLabel?: string;
+  /**
+   * if defined in conjunction with `secondaryActionLabel`, renders a text
+   * `Button` for a secondary action
+   * 
+   * @optional
+   */
+  secondaryAction?: (args?: any) => void;
+  /**
+   * `Button` label for the secondary action
+   * 
+   * @optional
+   */
+  secondaryActionLabel?: string;
+}
+
+const BannerRoot = styled('div', { name: 'BannerRoot' })(e_sx({
+  padding: '16px 24px',
+  borderRadius: 8,
+  backgroundColor: 'blue.100',
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+const Banner = ({
+  title,
+  description,
+  showStartIcon = false,
+  onClose,
+  primaryAction,
+  primaryActionLabel,
+  secondaryAction,
+  secondaryActionLabel,
+}: BannerProps): JSX.Element => (
+  <BannerRoot>
+    {onClose &&
+      <IconButton
+        onClick={onClose}
+        sx={{
+          position: 'absolute',
+          top: 2,
+          right: 8,
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
+    }
+    <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
+      {showStartIcon && <InfoOutlinedIcon sx={{ mr: 0.5 }} />}
+      <Typography variant="p2" weight="semibold">
+        {title}
+      </Typography>
+    </Box>
+    <Typography variant="p3">
+      {description}
+    </Typography>
+    <Box
+      sx={{
+        display: 'flex',
+        alignSelf: {
+          xs: 'stretch',
+          sm: 'flex-end',
+        },
+        flexDirection: {
+          xs: 'column',
+          sm: 'row',
+        },
+        flexFlow: {
+          xs: 'column-reverse',
+          sm: 'unset',
+        },
+        mt: { xs: 2, sm: 0 },
+      }}
+    >
+      {secondaryAction && secondaryActionLabel &&
+        <Button
+          variant="text"
+          color="blue"
+          onClick={secondaryAction}
+          sx={{
+            mr: { sm: 3 },
+            mt: { xs: 2, sm: 0 },
+            '&:hover': {
+              backgroundColor: 'blue.300',
+            },
+          }}
+        >
+          {secondaryActionLabel}
+        </Button>
+      }
+      {primaryAction && primaryActionLabel &&
+        <Button
+          variant="primary"
+          color="blue"
+          endIcon={<ArrowForwardIcon />}
+          onClick={primaryAction}
+        >
+          {primaryActionLabel}
+        </Button>
+      }
+    </Box>
+  </BannerRoot>
+);
+
+export default Banner;

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Banner';

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -104,6 +104,10 @@ const ButtonRoot = styled(MuiButton)(({ theme, variant }) => ({
     /** @TODO confirm that text buttons don't follow the same min width rules */
     minWidth: 'min-content',
     padding: '0px 16px',
+    paddingRight: 0,
+    paddingLeft: 0,
+    marginRight: 16,
+    marginLeft: 16,
   }),
 }));
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -39,3 +39,6 @@ export * from './TextField/TextField';
 
 export { default as InlineNotification } from './InlineNotification';
 export * from './InlineNotification/InlineNotification';
+
+export { default as Banner } from './Banner';
+export * from './Banner/Banner';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   ImageGridItem,
   ImageGrid,
   InlineNotification,
+  Banner,
 } from './components';
 export * from '@mui/material';
 
@@ -56,4 +57,5 @@ export {
   ImageGridItem,
   ImageGrid,
   InlineNotification,
+  Banner,
 };


### PR DESCRIPTION
#### Description:
`Banner` component that we'll use for informational notifications and callouts. The most basic version of this component requires a `description`; all other props are optional. If both a primary and secondary action are defined, the buttons appear at the far right end on desktop and will stack on mobile web.

#### Figma:
https://www.figma.com/file/xfmzo1QWKiFbf2tx7Q2NUa/HAJIMARI-Design-System?node-id=727%3A7347

#### Screenshots:
<img width="694" alt="banner mobile" src="https://user-images.githubusercontent.com/9397381/171329717-164d5bdd-dca1-4677-8e63-d39084e95ec4.png">
<img width="1904" alt="banner 2" src="https://user-images.githubusercontent.com/9397381/171329728-6dab6b2a-8429-4dfa-90fa-b756247ff3ca.png">
<img width="1904" alt="banner 1" src="https://user-images.githubusercontent.com/9397381/171329733-aadff325-5c74-436d-8756-bae8bf235527.png">

