### PR TITLE
[ROK-965] confirmation modal

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -3,253 +3,20 @@ import { BoxProps as BoxProps$1 } from '@mui/material/Box';
 import React$1 from 'react';
 import { ButtonProps as ButtonProps$1 } from '@mui/material/Button';
 import { LinkProps } from 'react-router-dom';
-import { IconButtonProps as IconButtonProps$1 } from '@mui/material/IconButton';
 import { CardProps as CardProps$1 } from '@mui/material/Card';
-import { CardHeaderProps as CardHeaderProps$1 } from '@mui/material/CardHeader';
 import { CardContentProps as CardContentProps$1 } from '@mui/material/CardContent';
-import { TypographyProps as TypographyProps$1 } from '@mui/material/Typography';
-import { ImageListItemProps } from '@mui/material/ImageListItem';
-import { ImageListProps } from '@mui/material/ImageList';
-import { AccordionProps } from '@mui/material/Accordion';
-import { ListProps as ListProps$1, ListItemProps as ListItemProps$1 } from '@mui/material';
+import { CardHeaderProps as CardHeaderProps$1 } from '@mui/material/CardHeader';
+import { DialogProps, ListProps as ListProps$1, ListItemProps as ListItemProps$1 } from '@mui/material';
 import { TextFieldProps as TextFieldProps$1 } from '@mui/material/TextField';
+import { IconButtonProps as IconButtonProps$1 } from '@mui/material/IconButton';
+import { ImageListProps } from '@mui/material/ImageList';
+import { ImageListItemProps } from '@mui/material/ImageListItem';
+import { AccordionProps } from '@mui/material/Accordion';
+import { TypographyProps as TypographyProps$1 } from '@mui/material/Typography';
 
 interface BoxProps extends BoxProps$1 {
 }
 declare const Box: (props: BoxProps) => JSX.Element;
-
-declare type HTMLAnchorProps = React$1.HTMLProps<HTMLAnchorElement>;
-interface ButtonProps<C> extends ButtonProps$1 {
-    /**
-     *
-     * This prop is only relevant for the `text` variant.
-     *
-     * The background type on which this Button is appears. Since we don't
-     * currently support light vs dark mode on web as a theme variant, we can
-     * use this prop to determine relevant styles.
-     *
-     * @default 'light'
-     */
-    bg?: BackgroundMode;
-    /**
-     * In order to use certain props that one would expect to have available on a button
-     * while satisfying typescript in accordance with MUI's component 'composition'
-     * rules, we have to do some forwardRef + generics shenanigans:
-     *
-     * https://mui.com/material-ui/guides/composition/#with-typescript
-     * https://github.com/mui/material-ui/issues/15827#issuecomment-809209533
-     *
-     */
-    component?: C | string;
-    to?: LinkProps['to'];
-    css?: any;
-    noStopPropagation?: boolean;
-    /**
-     * It appears there are some type limitations when it comes to passing in
-     * props that an HTML anchor element would accept as attributes; so for now,
-     * we'll manually declare these types so that they can be accessed.
-     */
-    download?: HTMLAnchorProps['download'];
-    target?: HTMLAnchorProps['target'];
-    rel?: HTMLAnchorProps['rel'];
-    /**
-     * If `true`, shows the button in a "loading state" with a circular progress indicator
-     * @default false
-     */
-    loading?: boolean;
-    /**
-     * Text to display in the button when `loading` is `true`.
-     * @default false
-     */
-    loadingIndicator?: string;
-}
-declare const Button: React$1.ForwardRefExoticComponent<Pick<ButtonProps<React$1.ComponentType<any>>, "className" | "style" | "classes" | "color" | "translate" | "form" | "slot" | "title" | "children" | "component" | "sx" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | "accessKey" | "contentEditable" | "contextMenu" | "dir" | "draggable" | "hidden" | "id" | "lang" | "placeholder" | "spellCheck" | "tabIndex" | "radioGroup" | "role" | "about" | "datatype" | "inlist" | "prefix" | "property" | "resource" | "typeof" | "vocab" | "autoCapitalize" | "autoCorrect" | "autoSave" | "itemProp" | "itemScope" | "itemType" | "itemID" | "itemRef" | "results" | "security" | "unselectable" | "inputMode" | "is" | "aria-activedescendant" | "aria-atomic" | "aria-autocomplete" | "aria-busy" | "aria-checked" | "aria-colcount" | "aria-colindex" | "aria-colspan" | "aria-controls" | "aria-current" | "aria-describedby" | "aria-details" | "aria-disabled" | "aria-dropeffect" | "aria-errormessage" | "aria-expanded" | "aria-flowto" | "aria-grabbed" | "aria-haspopup" | "aria-hidden" | "aria-invalid" | "aria-keyshortcuts" | "aria-label" | "aria-labelledby" | "aria-level" | "aria-live" | "aria-modal" | "aria-multiline" | "aria-multiselectable" | "aria-orientation" | "aria-owns" | "aria-placeholder" | "aria-posinset" | "aria-pressed" | "aria-readonly" | "aria-relevant" | "aria-required" | "aria-roledescription" | "aria-rowcount" | "aria-rowindex" | "aria-rowspan" | "aria-selected" | "aria-setsize" | "aria-sort" | "aria-valuemax" | "aria-valuemin" | "aria-valuenow" | "aria-valuetext" | "dangerouslySetInnerHTML" | "onCopy" | "onCopyCapture" | "onCut" | "onCutCapture" | "onPaste" | "onPasteCapture" | "onCompositionEnd" | "onCompositionEndCapture" | "onCompositionStart" | "onCompositionStartCapture" | "onCompositionUpdate" | "onCompositionUpdateCapture" | "onFocus" | "onFocusCapture" | "onBlur" | "onBlurCapture" | "onChange" | "onChangeCapture" | "onBeforeInput" | "onBeforeInputCapture" | "onInput" | "onInputCapture" | "onReset" | "onResetCapture" | "onSubmit" | "onSubmitCapture" | "onInvalid" | "onInvalidCapture" | "onLoad" | "onLoadCapture" | "onError" | "onErrorCapture" | "onKeyDown" | "onKeyDownCapture" | "onKeyPress" | "onKeyPressCapture" | "onKeyUp" | "onKeyUpCapture" | "onAbort" | "onAbortCapture" | "onCanPlay" | "onCanPlayCapture" | "onCanPlayThrough" | "onCanPlayThroughCapture" | "onDurationChange" | "onDurationChangeCapture" | "onEmptied" | "onEmptiedCapture" | "onEncrypted" | "onEncryptedCapture" | "onEnded" | "onEndedCapture" | "onLoadedData" | "onLoadedDataCapture" | "onLoadedMetadata" | "onLoadedMetadataCapture" | "onLoadStart" | "onLoadStartCapture" | "onPause" | "onPauseCapture" | "onPlay" | "onPlayCapture" | "onPlaying" | "onPlayingCapture" | "onProgress" | "onProgressCapture" | "onRateChange" | "onRateChangeCapture" | "onSeeked" | "onSeekedCapture" | "onSeeking" | "onSeekingCapture" | "onStalled" | "onStalledCapture" | "onSuspend" | "onSuspendCapture" | "onTimeUpdate" | "onTimeUpdateCapture" | "onVolumeChange" | "onVolumeChangeCapture" | "onWaiting" | "onWaitingCapture" | "onAuxClick" | "onAuxClickCapture" | "onClick" | "onClickCapture" | "onContextMenu" | "onContextMenuCapture" | "onDoubleClick" | "onDoubleClickCapture" | "onDrag" | "onDragCapture" | "onDragEnd" | "onDragEndCapture" | "onDragEnter" | "onDragEnterCapture" | "onDragExit" | "onDragExitCapture" | "onDragLeave" | "onDragLeaveCapture" | "onDragOver" | "onDragOverCapture" | "onDragStart" | "onDragStartCapture" | "onDrop" | "onDropCapture" | "onMouseDown" | "onMouseDownCapture" | "onMouseEnter" | "onMouseLeave" | "onMouseMove" | "onMouseMoveCapture" | "onMouseOut" | "onMouseOutCapture" | "onMouseOver" | "onMouseOverCapture" | "onMouseUp" | "onMouseUpCapture" | "onSelect" | "onSelectCapture" | "onTouchCancel" | "onTouchCancelCapture" | "onTouchEnd" | "onTouchEndCapture" | "onTouchMove" | "onTouchMoveCapture" | "onTouchStart" | "onTouchStartCapture" | "onPointerDown" | "onPointerDownCapture" | "onPointerMove" | "onPointerMoveCapture" | "onPointerUp" | "onPointerUpCapture" | "onPointerCancel" | "onPointerCancelCapture" | "onPointerEnter" | "onPointerEnterCapture" | "onPointerLeave" | "onPointerLeaveCapture" | "onPointerOver" | "onPointerOverCapture" | "onPointerOut" | "onPointerOutCapture" | "onGotPointerCapture" | "onGotPointerCaptureCapture" | "onLostPointerCapture" | "onLostPointerCaptureCapture" | "onScroll" | "onScrollCapture" | "onWheel" | "onWheelCapture" | "onAnimationStart" | "onAnimationStartCapture" | "onAnimationEnd" | "onAnimationEndCapture" | "onAnimationIteration" | "onAnimationIterationCapture" | "onTransitionEnd" | "onTransitionEndCapture" | "css" | "size" | "disabled" | "name" | "target" | "type" | "href" | "to" | "download" | "rel" | "autoFocus" | "formAction" | "formEncType" | "formMethod" | "formNoValidate" | "formTarget" | "value" | "action" | "loading" | "fullWidth" | "disableElevation" | "startIcon" | "endIcon" | "variant" | "centerRipple" | "disableRipple" | "disableTouchRipple" | "focusRipple" | "focusVisibleClassName" | "LinkComponent" | "onFocusVisible" | "TouchRippleProps" | "touchRippleRef" | "disableFocusRipple" | "bg" | "noStopPropagation" | "loadingIndicator"> & React$1.RefAttributes<HTMLButtonElement>>;
-
-declare type IconButtonProps = {
-    /**
-     * The background type that this IconButton is appearing on. Since we don't
-     * currently support light vs dark mode on web as a theme variant, we can
-     * use this prop to determine relevant styles.
-     *
-     * @default 'light'
-     */
-    bg?: BackgroundMode;
-} & IconButtonProps$1;
-declare const IconButton: (props: IconButtonProps) => JSX.Element;
-
-interface CardColorProperty {
-    border?: CommonColor;
-    bg?: CommonColor;
-}
-interface CardProps extends CardProps$1, CardColorProperty {
-}
-declare const Card: ({ border, children, bg, sx, ...props }: CardProps) => JSX.Element;
-
-interface CardHeaderProps extends CardHeaderProps$1 {
-    bottomDivider?: boolean;
-    border?: CommonColor;
-    bg?: CommonColor;
-}
-declare const CardHeader: ({ bottomDivider, children, bg, sx, ...otherProps }: CardHeaderProps) => JSX.Element;
-
-interface CardContentProps extends CardContentProps$1 {
-    border?: CommonColor;
-    bg?: CommonColor;
-}
-declare const CardContent: ({ children, bg, ...props }: CardContentProps) => JSX.Element;
-
-declare type FontWeightVariant = 'regular' | 'medium' | 'semibold';
-declare type FontWeightValue = 400 | 500 | 600;
-declare type FontWeight = {
-    [w in FontWeightVariant]: FontWeightValue;
-};
-declare const fontWeights: FontWeight;
-interface TypographyProps extends TypographyProps$1 {
-    /**
-     * @default 'regular'
-     */
-    weight?: FontWeightVariant;
-    /**
-     * When using MUI in combination with styled/emotion, we lose access
-     * to the component prop. This appears to be a limitation of Typescript;
-     * doing this is a workaround:
-     *
-     * https://github.com/mui/material-ui/issues/15695#issuecomment-1026602904
-     */
-    component?: React$1.ElementType;
-}
-declare const Typography: (props: TypographyProps) => JSX.Element;
-
-interface LineItemProps {
-    leftContent: React$1.ReactNode;
-    rightContent: React$1.ReactNode;
-    width?: number | string;
-}
-declare const LineItem: ({ leftContent, rightContent, width, }: LineItemProps) => JSX.Element;
-
-interface InformationCardProps {
-    title: string;
-    children: React.ReactNode;
-}
-declare const InformationCard: ({ title, children }: InformationCardProps) => JSX.Element;
-
-interface ImageItem {
-    /**
-     * The source string of an image, accepts the same values as the src prop
-     * of a the standard HTML img element
-     */
-    src: string;
-    /**
-     * A useful description of the image
-     */
-    alt: string;
-}
-interface ImageGridItemProps extends ImageListItemProps {
-    src: ImageItem['src'];
-    alt: ImageItem['alt'];
-    action?: React.ReactNode;
-}
-declare const ImageGridItem: ({ src, alt, action, ...props }: ImageGridItemProps) => JSX.Element;
-
-interface ImageGridProps extends ImageListProps {
-}
-declare const ImageGrid: ({ children, ...props }: ImageGridProps) => JSX.Element;
-
-declare type SuggestedActionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
-interface SuggestedActionProps {
-    variant: SuggestedActionVariant;
-    description: React$1.ReactNode;
-    onClickMenu: () => void;
-    dueDate?: string;
-    cta: string;
-    ctaAction: () => void;
-    secondaryCta?: string;
-    secondaryCtaAction?: () => void;
-}
-declare const SuggestedAction: ({ variant, description, onClickMenu, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, }: SuggestedActionProps) => JSX.Element;
-
-declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
-interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {
-    variant: SuggestedActionAccordionVariant;
-    groupTitle: string;
-    numItems: number;
-    highlightNumber?: boolean;
-}
-declare const SuggestedActionAccordion: ({ variant, groupTitle, numItems, highlightNumber, children, ...otherProps }: SuggestedActionAccordionProps) => JSX.Element;
-
-interface ListProps extends ListProps$1 {
-    /**
-     * pass in list items as children
-     * @default undefined
-     */
-    children: React$1.ReactNode;
-    /**
-     * if a hajimari color is specified, the list will have a border
-     * @default undefined
-     */
-    border?: HajimariColor;
-}
-declare const List: ({ children, border }: ListProps) => JSX.Element;
-
-interface ListItemProps extends ListItemProps$1 {
-    /**
-     * The main text of list item row
-     * @default undefined
-     * @optional
-     */
-    headerText?: string;
-    /**
-     * a sorta subheader or more text to supplement main header
-     * @optional
-     */
-    description?: string;
-    /**
-     * primary actions are passed in as children. current use cases include button, toggle, and expand.
-     * if no children is passed in, list item will display text row.
-     * @optional
-     */
-    children?: React$1.ReactNode;
-    /**
-     * if true, headerText will be bolded
-     * @optional
-     * @default false
-     */
-    isHeader?: boolean;
-}
-declare const ListItem: ({ headerText, description, children, divider, isHeader, }: ListItemProps) => JSX.Element;
-
-declare enum NotificationVariant {
-    info = "info",
-    warning = "warning",
-    error = "error"
-}
-interface InlineNotificationProps extends BoxProps {
-    /**
-     * Inline notifications are constrained to `info`, `warning`, or `error`.
-     * Since the default value is `info`, the default component will have styles
-     * related to that variant.
-     * @default `info`
-     */
-    variant?: NotificationVariant;
-    onClose?: (args?: any) => void;
-    /**
-     *
-     * @default false
-     */
-    showStartIcon?: boolean;
-    /**
-     * @optional function to do some kind of action
-     */
-    action?: (args?: any) => void;
-    /**
-     * the text of the actual button. If an `action` is provided without an `actionLabel`,
-     * a standalone arrow icon will appear as the CTA
-     *
-     * @default undefined
-     *  */
-    actionLabel?: string;
-}
-declare const InlineNotification: ({ children, variant, onClose, showStartIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
 
 interface BannerProps extends BoxProps {
     /**
@@ -302,15 +69,89 @@ interface BannerProps extends BoxProps {
 }
 declare const Banner: ({ title, description, showStartIcon, onClose, primaryAction, primaryActionLabel, secondaryAction, secondaryActionLabel, }: BannerProps) => JSX.Element;
 
-declare type Mask = 'money' | 'moneyWithCents' | 'ssn' | 'lastFourSsn' | 'bankNumber' | 'phone' | 'percent' | 'taxId' | 'year' | 'default' | 'search' | 'date';
+declare type HTMLAnchorProps = React$1.HTMLProps<HTMLAnchorElement>;
+interface ButtonProps<C> extends ButtonProps$1 {
+    /**
+     *
+     * This prop is only relevant for the `text` variant.
+     *
+     * The background type on which this Button is appears. Since we don't
+     * currently support light vs dark mode on web as a theme variant, we can
+     * use this prop to determine relevant styles.
+     *
+     * @default 'light'
+     */
+    bg?: BackgroundMode;
+    /**
+     * In order to use certain props that one would expect to have available on a button
+     * while satisfying typescript in accordance with MUI's component 'composition'
+     * rules, we have to do some forwardRef + generics shenanigans:
+     *
+     * https://mui.com/material-ui/guides/composition/#with-typescript
+     * https://github.com/mui/material-ui/issues/15827#issuecomment-809209533
+     *
+     */
+    component?: C | string;
+    to?: LinkProps['to'];
+    css?: any;
+    noStopPropagation?: boolean;
+    /**
+     * It appears there are some type limitations when it comes to passing in
+     * props that an HTML anchor element would accept as attributes; so for now,
+     * we'll manually declare these types so that they can be accessed.
+     */
+    download?: HTMLAnchorProps['download'];
+    target?: HTMLAnchorProps['target'];
+    rel?: HTMLAnchorProps['rel'];
+    /**
+     * If `true`, shows the button in a "loading state" with a circular progress indicator
+     * @default false
+     */
+    loading?: boolean;
+    /**
+     * Text to display in the button when `loading` is `true`.
+     * @default false
+     */
+    loadingIndicator?: string;
+}
+declare const Button: React$1.ForwardRefExoticComponent<Pick<ButtonProps<React$1.ComponentType<any>>, "className" | "style" | "classes" | "color" | "translate" | "form" | "slot" | "title" | "children" | "component" | "sx" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | "accessKey" | "contentEditable" | "contextMenu" | "dir" | "draggable" | "hidden" | "id" | "lang" | "placeholder" | "spellCheck" | "tabIndex" | "radioGroup" | "role" | "about" | "datatype" | "inlist" | "prefix" | "property" | "resource" | "typeof" | "vocab" | "autoCapitalize" | "autoCorrect" | "autoSave" | "itemProp" | "itemScope" | "itemType" | "itemID" | "itemRef" | "results" | "security" | "unselectable" | "inputMode" | "is" | "aria-activedescendant" | "aria-atomic" | "aria-autocomplete" | "aria-busy" | "aria-checked" | "aria-colcount" | "aria-colindex" | "aria-colspan" | "aria-controls" | "aria-current" | "aria-describedby" | "aria-details" | "aria-disabled" | "aria-dropeffect" | "aria-errormessage" | "aria-expanded" | "aria-flowto" | "aria-grabbed" | "aria-haspopup" | "aria-hidden" | "aria-invalid" | "aria-keyshortcuts" | "aria-label" | "aria-labelledby" | "aria-level" | "aria-live" | "aria-modal" | "aria-multiline" | "aria-multiselectable" | "aria-orientation" | "aria-owns" | "aria-placeholder" | "aria-posinset" | "aria-pressed" | "aria-readonly" | "aria-relevant" | "aria-required" | "aria-roledescription" | "aria-rowcount" | "aria-rowindex" | "aria-rowspan" | "aria-selected" | "aria-setsize" | "aria-sort" | "aria-valuemax" | "aria-valuemin" | "aria-valuenow" | "aria-valuetext" | "dangerouslySetInnerHTML" | "onCopy" | "onCopyCapture" | "onCut" | "onCutCapture" | "onPaste" | "onPasteCapture" | "onCompositionEnd" | "onCompositionEndCapture" | "onCompositionStart" | "onCompositionStartCapture" | "onCompositionUpdate" | "onCompositionUpdateCapture" | "onFocus" | "onFocusCapture" | "onBlur" | "onBlurCapture" | "onChange" | "onChangeCapture" | "onBeforeInput" | "onBeforeInputCapture" | "onInput" | "onInputCapture" | "onReset" | "onResetCapture" | "onSubmit" | "onSubmitCapture" | "onInvalid" | "onInvalidCapture" | "onLoad" | "onLoadCapture" | "onError" | "onErrorCapture" | "onKeyDown" | "onKeyDownCapture" | "onKeyPress" | "onKeyPressCapture" | "onKeyUp" | "onKeyUpCapture" | "onAbort" | "onAbortCapture" | "onCanPlay" | "onCanPlayCapture" | "onCanPlayThrough" | "onCanPlayThroughCapture" | "onDurationChange" | "onDurationChangeCapture" | "onEmptied" | "onEmptiedCapture" | "onEncrypted" | "onEncryptedCapture" | "onEnded" | "onEndedCapture" | "onLoadedData" | "onLoadedDataCapture" | "onLoadedMetadata" | "onLoadedMetadataCapture" | "onLoadStart" | "onLoadStartCapture" | "onPause" | "onPauseCapture" | "onPlay" | "onPlayCapture" | "onPlaying" | "onPlayingCapture" | "onProgress" | "onProgressCapture" | "onRateChange" | "onRateChangeCapture" | "onSeeked" | "onSeekedCapture" | "onSeeking" | "onSeekingCapture" | "onStalled" | "onStalledCapture" | "onSuspend" | "onSuspendCapture" | "onTimeUpdate" | "onTimeUpdateCapture" | "onVolumeChange" | "onVolumeChangeCapture" | "onWaiting" | "onWaitingCapture" | "onAuxClick" | "onAuxClickCapture" | "onClick" | "onClickCapture" | "onContextMenu" | "onContextMenuCapture" | "onDoubleClick" | "onDoubleClickCapture" | "onDrag" | "onDragCapture" | "onDragEnd" | "onDragEndCapture" | "onDragEnter" | "onDragEnterCapture" | "onDragExit" | "onDragExitCapture" | "onDragLeave" | "onDragLeaveCapture" | "onDragOver" | "onDragOverCapture" | "onDragStart" | "onDragStartCapture" | "onDrop" | "onDropCapture" | "onMouseDown" | "onMouseDownCapture" | "onMouseEnter" | "onMouseLeave" | "onMouseMove" | "onMouseMoveCapture" | "onMouseOut" | "onMouseOutCapture" | "onMouseOver" | "onMouseOverCapture" | "onMouseUp" | "onMouseUpCapture" | "onSelect" | "onSelectCapture" | "onTouchCancel" | "onTouchCancelCapture" | "onTouchEnd" | "onTouchEndCapture" | "onTouchMove" | "onTouchMoveCapture" | "onTouchStart" | "onTouchStartCapture" | "onPointerDown" | "onPointerDownCapture" | "onPointerMove" | "onPointerMoveCapture" | "onPointerUp" | "onPointerUpCapture" | "onPointerCancel" | "onPointerCancelCapture" | "onPointerEnter" | "onPointerEnterCapture" | "onPointerLeave" | "onPointerLeaveCapture" | "onPointerOver" | "onPointerOverCapture" | "onPointerOut" | "onPointerOutCapture" | "onGotPointerCapture" | "onGotPointerCaptureCapture" | "onLostPointerCapture" | "onLostPointerCaptureCapture" | "onScroll" | "onScrollCapture" | "onWheel" | "onWheelCapture" | "onAnimationStart" | "onAnimationStartCapture" | "onAnimationEnd" | "onAnimationEndCapture" | "onAnimationIteration" | "onAnimationIterationCapture" | "onTransitionEnd" | "onTransitionEndCapture" | "css" | "size" | "disabled" | "name" | "target" | "type" | "href" | "to" | "download" | "rel" | "autoFocus" | "formAction" | "formEncType" | "formMethod" | "formNoValidate" | "formTarget" | "value" | "action" | "loading" | "fullWidth" | "disableElevation" | "startIcon" | "endIcon" | "variant" | "centerRipple" | "disableRipple" | "disableTouchRipple" | "focusRipple" | "focusVisibleClassName" | "LinkComponent" | "onFocusVisible" | "TouchRippleProps" | "touchRippleRef" | "disableFocusRipple" | "bg" | "noStopPropagation" | "loadingIndicator"> & React$1.RefAttributes<HTMLButtonElement>>;
 
-declare type TextFieldProps = {
-    mask: Mask;
-    value?: string;
-} & TextFieldProps$1;
-declare const TextField: ({ mask, value, onChange, ...otherProps }: TextFieldProps) => JSX.Element;
+interface CardColorProperty {
+    border?: CommonColor;
+    bg?: CommonColor;
+}
+interface CardProps extends CardProps$1, CardColorProperty {
+}
+declare const Card: ({ border, children, bg, sx, ...props }: CardProps) => JSX.Element;
 
-declare const StatefulTextField: (props: TextFieldProps) => JSX.Element;
+interface CardContentProps extends CardContentProps$1 {
+    border?: CommonColor;
+    bg?: CommonColor;
+}
+declare const CardContent: ({ children, bg, ...props }: CardContentProps) => JSX.Element;
+
+interface CardHeaderProps extends CardHeaderProps$1 {
+    bottomDivider?: boolean;
+    border?: CommonColor;
+    bg?: CommonColor;
+}
+declare const CardHeader: ({ bottomDivider, children, bg, sx, ...otherProps }: CardHeaderProps) => JSX.Element;
+
+declare type ConfirmationModalVariant = 'greyscale' | 'blue' | 'green' | 'yellow' | 'red';
+interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
+    variant?: ConfirmationModalVariant;
+    open: boolean;
+    onClose: () => void;
+    onOpen?: () => void;
+    title: React$1.ReactNode;
+    body: React$1.ReactNode;
+    primaryAction: () => void;
+    primaryActionCopy: string;
+    secondaryActionCopy: string;
+    linkBackAction?: () => void;
+    linkBackCopy?: React$1.ReactNode;
+}
+declare const ConfirmationModal: ({ variant, open, onClose, onOpen, title, body, primaryAction, primaryActionCopy, secondaryActionCopy, linkBackAction, linkBackCopy, ...otherProps }: ConfirmationModalProps) => JSX.Element;
 
 interface DatePickerProps {
     name: string;
@@ -323,4 +164,179 @@ interface DatePickerProps {
 }
 declare const DatePickerField: ({ name, label, helperText, textFieldProps, onChangeCallback, onBlurCallback, error, ...otherProps }: DatePickerProps) => JSX.Element;
 
-export { Banner, BannerProps, Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, DatePickerField as DatePicker, DatePickerProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, List, ListItem, ListItemProps, ListProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionAccordion, SuggestedActionAccordionProps, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };
+declare type IconButtonProps = {
+    /**
+     * The background type that this IconButton is appearing on. Since we don't
+     * currently support light vs dark mode on web as a theme variant, we can
+     * use this prop to determine relevant styles.
+     *
+     * @default 'light'
+     */
+    bg?: BackgroundMode;
+} & IconButtonProps$1;
+declare const IconButton: (props: IconButtonProps) => JSX.Element;
+
+interface ImageGridProps extends ImageListProps {
+}
+declare const ImageGrid: ({ children, ...props }: ImageGridProps) => JSX.Element;
+
+interface ImageItem {
+    /**
+     * The source string of an image, accepts the same values as the src prop
+     * of a the standard HTML img element
+     */
+    src: string;
+    /**
+     * A useful description of the image
+     */
+    alt: string;
+}
+interface ImageGridItemProps extends ImageListItemProps {
+    src: ImageItem['src'];
+    alt: ImageItem['alt'];
+    action?: React.ReactNode;
+}
+declare const ImageGridItem: ({ src, alt, action, ...props }: ImageGridItemProps) => JSX.Element;
+
+interface InformationCardProps {
+    title: string;
+    children: React.ReactNode;
+}
+declare const InformationCard: ({ title, children }: InformationCardProps) => JSX.Element;
+
+declare enum NotificationVariant {
+    info = "info",
+    warning = "warning",
+    error = "error"
+}
+interface InlineNotificationProps extends BoxProps {
+    /**
+     * Inline notifications are constrained to `info`, `warning`, or `error`.
+     * Since the default value is `info`, the default component will have styles
+     * related to that variant.
+     * @default `info`
+     */
+    variant?: NotificationVariant;
+    onClose?: (args?: any) => void;
+    /**
+     *
+     * @default false
+     */
+    showStartIcon?: boolean;
+    /**
+     * @optional function to do some kind of action
+     */
+    action?: (args?: any) => void;
+    /**
+     * the text of the actual button. If an `action` is provided without an `actionLabel`,
+     * a standalone arrow icon will appear as the CTA
+     *
+     * @default undefined
+     *  */
+    actionLabel?: string;
+}
+declare const InlineNotification: ({ children, variant, onClose, showStartIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
+
+interface LineItemProps {
+    leftContent: React$1.ReactNode;
+    rightContent: React$1.ReactNode;
+    width?: number | string;
+}
+declare const LineItem: ({ leftContent, rightContent, width, }: LineItemProps) => JSX.Element;
+
+interface ListProps extends ListProps$1 {
+    /**
+     * pass in list items as children
+     * @default undefined
+     */
+    children: React$1.ReactNode;
+    /**
+     * if a hajimari color is specified, the list will have a border
+     * @default undefined
+     */
+    border?: HajimariColor;
+}
+declare const List: ({ children, border }: ListProps) => JSX.Element;
+
+interface ListItemProps extends ListItemProps$1 {
+    /**
+     * The main text of list item row
+     * @default undefined
+     * @optional
+     */
+    headerText?: string;
+    /**
+     * a sorta subheader or more text to supplement main header
+     * @optional
+     */
+    description?: string;
+    /**
+     * primary actions are passed in as children. current use cases include button, toggle, and expand.
+     * if no children is passed in, list item will display text row.
+     * @optional
+     */
+    children?: React$1.ReactNode;
+    /**
+     * if true, headerText will be bolded
+     * @optional
+     * @default false
+     */
+    isHeader?: boolean;
+}
+declare const ListItem: ({ headerText, description, children, divider, isHeader, }: ListItemProps) => JSX.Element;
+
+declare type SuggestedActionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
+interface SuggestedActionProps {
+    variant: SuggestedActionVariant;
+    description: React$1.ReactNode;
+    onClickMenu: () => void;
+    dueDate?: string;
+    cta: string;
+    ctaAction: () => void;
+    secondaryCta?: string;
+    secondaryCtaAction?: () => void;
+}
+declare const SuggestedAction: ({ variant, description, onClickMenu, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, }: SuggestedActionProps) => JSX.Element;
+
+declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
+interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {
+    variant: SuggestedActionAccordionVariant;
+    groupTitle: string;
+    numItems: number;
+    highlightNumber?: boolean;
+}
+declare const SuggestedActionAccordion: ({ variant, groupTitle, numItems, highlightNumber, children, ...otherProps }: SuggestedActionAccordionProps) => JSX.Element;
+
+declare type Mask = 'money' | 'moneyWithCents' | 'ssn' | 'lastFourSsn' | 'bankNumber' | 'phone' | 'percent' | 'taxId' | 'year' | 'default' | 'search' | 'date';
+
+declare type TextFieldProps = {
+    mask: Mask;
+    value?: string;
+} & TextFieldProps$1;
+declare const TextField: ({ mask, value, onChange, ...otherProps }: TextFieldProps) => JSX.Element;
+
+declare const StatefulTextField: (props: TextFieldProps) => JSX.Element;
+
+declare type FontWeightVariant = 'regular' | 'medium' | 'semibold';
+declare type FontWeightValue = 400 | 500 | 600;
+declare type FontWeight = {
+    [w in FontWeightVariant]: FontWeightValue;
+};
+declare const fontWeights: FontWeight;
+interface TypographyProps extends TypographyProps$1 {
+    /**
+     * @default 'regular'
+     */
+    weight?: FontWeightVariant;
+    /**
+     * When using MUI in combination with styled/emotion, we lose access
+     * to the component prop. This appears to be a limitation of Typescript;
+     * doing this is a workaround:
+     *
+     * https://github.com/mui/material-ui/issues/15695#issuecomment-1026602904
+     */
+    component?: React$1.ElementType;
+}
+declare const Typography: (props: TypographyProps) => JSX.Element;
+
+export { Banner, BannerProps, Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, ConfirmationModal, ConfirmationModalProps, ConfirmationModalVariant, DatePickerField as DatePicker, DatePickerProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, List, ListItem, ListItemProps, ListProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionAccordion, SuggestedActionAccordionProps, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -143,7 +143,7 @@ interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
     open: boolean;
     onClose: () => void;
     onOpen?: () => void;
-    title: React$1.ReactNode;
+    title?: React$1.ReactNode;
     body: React$1.ReactNode;
     primaryAction: () => void;
     primaryActionCopy: string;

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -1,6 +1,5 @@
 import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import { withDesign } from 'storybook-addon-designs';
-import { MemoryRouter } from 'react-router-dom';
 
 import ConfirmationModal from './ConfirmationModal';
 import Box from '../Box';
@@ -65,12 +64,8 @@ export const argTypes = {
       type: { summary: 'string' },
     },
   },
-  linkBackTo: {
-    defaultValue: '#',
-    control: { type: 'text' },
-    table: {
-      type: { summary: 'string' },
-    },
+  linkBackAction: {
+    defaultValue: () => {},
   },
   linkBackCopy: {
     defaultValue: 'Back to dashboard',
@@ -94,11 +89,7 @@ export const argTypes = {
   }}
 />
 
-export const ConfirmationModalTemplate = (args) => (
-  <MemoryRouter>
-    <ConfirmationModal {...args} />
-  </MemoryRouter>
-);
+export const ConfirmationModalTemplate = (args) => <ConfirmationModal {...args} />;
 
 # ConfirmationModal
 
@@ -129,10 +120,11 @@ it has a `primaryActionCopy` prop, which is the `string` displayed in the confir
 Finally, it has a `secondaryActionCopy` prop, which is the `string` displayed in the cancel
 button.
 
-Optionally, it takes `string`s for `linkBackTo` and `linkBackCopy`, which set the path to
-which the link redirects and the copy the link displays, respectively; if these props are
-provided, the link appears above the header. Also optionally, it has an `onOpen` prop, which
-specifies a function that runs when the modal opens. This prop is useful for analytics tracking.
+Optionally, it takes `string`s for `linkBackAction` and `linkBackCopy`, which set action
+that occurs when the link is clcked and the copy the link displays, respectively; if these
+props are provided, the link appears above the header. Also optionally, it has an `onOpen`
+prop, which specifies a function that runs when the modal opens. This prop is useful for
+analytics tracking.
 
 <br />
 
@@ -154,7 +146,7 @@ a link back to another page, as well as an `onOpen` action.
       primaryAction: () => {},
       primaryActionCopy: 'Confirm',
       secondaryActionCopy: 'Cancel',
-      linkBackTo: null,
+      linkBackAction: null,
       linkBackCopy: null,
     }}
   >
@@ -164,7 +156,7 @@ a link back to another page, as well as an `onOpen` action.
 
 #### Back link:
 
-> Optionally, the `ConfirmationModal` accepts values for `linkBackTo`
+> Optionally, the `ConfirmationModal` accepts values for `linkBackAction`
 and `linkBackCopy`, which add a link to the upper left above the modal title.
 
 <Canvas>
@@ -180,7 +172,7 @@ and `linkBackCopy`, which add a link to the upper left above the modal title.
       primaryAction: () => {},
       primaryActionCopy: 'Confirm',
       secondaryActionCopy: 'Cancel',
-      linkBackTo: '#',
+      linkBackAction: () => {},
       linkBackCopy: 'Back to dashboard',
     }}
   >
@@ -208,7 +200,7 @@ e.g., implementing analytics events.
       primaryAction: () => {},
       primaryActionCopy: 'Confirm',
       secondaryActionCopy: 'Cancel',
-      linkBackTo: null,
+      linkBackAction: null,
       linkBackCopy: null,
     }}
   >

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -1,0 +1,234 @@
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import { withDesign } from 'storybook-addon-designs';
+import { MemoryRouter } from 'react-router-dom';
+
+import ConfirmationModal from './ConfirmationModal';
+import Box from '../Box';
+import Typography from '../Typography';
+
+export const argTypes = {
+  variant: {
+    control: { type: "select" },
+    options: ["blue", "green", "yellow", "red", "greyscale"],
+    defaultValue: "blue",
+    type: { required: true },
+    table: {
+      type: {
+        summary: '"blue" | "green" | "yellow" | "red" | "greyscale"',
+      },
+    },
+  },
+  open: {
+    control: { type: "boolean" },
+    defaultValue: true,
+    table: {
+      type: {
+        summary: 'true | false',
+        defaultValue: true,
+      },
+    },
+  },
+  onClose: {
+    defaultValue: () => {},
+  },
+  onOpen: {
+    defaultValue: () => {},
+  },
+  title: {
+    defaultValue: 'Discard progress?',
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  body: {
+    defaultValue: 'Are you sure you want to discard your progress?',
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  primaryAction: {
+    defaultValue: () => {},
+  },
+  primaryActionCopy: {
+    defaultValue: 'Confirm',
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  secondaryActionCopy: {
+    defaultValue: 'Cancel',
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  linkBackTo: {
+    defaultValue: '#',
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  linkBackCopy: {
+    defaultValue: 'Back to dashboard',
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+};
+
+<Meta
+  title="Molecules/ConfirmationModal"
+  component={ConfirmationModal}
+  argTypes={argTypes}
+  parameters={{
+    layout: 'padded',
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/xfmzo1QWKiFbf2tx7Q2NUa/HAJIMARI-Design-System?node-id=766%3A8102',
+    },
+  }}
+/>
+
+export const ConfirmationModalTemplate = (args) => (
+  <MemoryRouter>
+    <ConfirmationModal {...args} />
+  </MemoryRouter>
+);
+
+# ConfirmationModal
+
+**DATE ADDED**: 06/27/22 | **PROJECT**: [Suggested Actions/Notifications](https://www.notion.so/gethearth/Suggested-Action-Notification-44baf25d61db4f67afc5e92752134614)
+
+A `ConfirmationModal` is a special case of the general `Dialog` component that
+confirms whether the contractor wants to take a particular (typically irreversible)
+course of action. If the contractor clicks the primary action button, the action
+is confirmed. If the contractor clicks the secondary action button or otherwise closes
+the modal, the action is canceled.
+
+<br />
+
+---
+
+<br />
+
+### Usage and examples
+
+It has a `variant` attribute, which determines the color of the confirm and cancel buttons.
+It has a `title` attribute, which takes in a `string` or a `ReactNode` that appears at the
+top of the modal. Similarly, it has a `body` attribute that also takes in a `string` or a
+`ReactNode` and appears below the `title`. It has an `open` attribute, which is a `boolean`
+that determines whether the modal is visible. It also has an `onClose` attribute, which
+takes in a function that is called when the modal is closed. It has a `primaryAction` prop,
+which takes in a function that is called when the user clicks the confirm button. Relatedly,
+it has a `primaryActionCopy` prop, which is the `string` displayed in the confirm button.
+Finally, it has a `secondaryActionCopy` prop, which is the `string` displayed in the cancel
+button.
+
+Optionally, it takes `string`s for `linkBackTo` and `linkBackCopy`, which set the path to
+which the link redirects and the copy the link displays, respectively; if these props are
+provided, the link appears above the header. Also optionally, it has an `onOpen` prop, which
+specifies a function that runs when the modal opens. This prop is useful for analytics tracking.
+
+<br />
+
+#### Default / Basic:
+
+> The most basic usage of a `ConfirmationModal`. The component lacks
+a link back to another page, as well as an `onOpen` action.
+
+<Canvas>
+  <Story
+    name="Basic"
+    component={ConfirmationModal}
+    args={{
+      variant: 'blue',
+      open: true,
+      onClose: () => {},
+      title: 'Discard progress?',
+      body: 'Are you sure you want to discard your progress?',
+      primaryAction: () => {},
+      primaryActionCopy: 'Confirm',
+      secondaryActionCopy: 'Cancel',
+      linkBackTo: null,
+      linkBackCopy: null,
+    }}
+  >
+    {ConfirmationModalTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### Back link:
+
+> Optionally, the `ConfirmationModal` accepts values for `linkBackTo`
+and `linkBackCopy`, which add a link to the upper left above the modal title.
+
+<Canvas>
+  <Story
+    name="Back Link"
+    component={ConfirmationModal}
+    args={{
+      variant: 'blue',
+      open: true,
+      onClose: () => {},
+      title: 'Discard progress?',
+      body: 'Are you sure you want to discard your progress?',
+      primaryAction: () => {},
+      primaryActionCopy: 'Confirm',
+      secondaryActionCopy: 'Cancel',
+      linkBackTo: '#',
+      linkBackCopy: 'Back to dashboard',
+    }}
+  >
+    {ConfirmationModalTemplate.bind()}
+  </Story>
+</Canvas>
+
+#### onOpen:
+
+> Optionally, the `ConfirmationModal` accepts a function for `onOpen`,
+which runs when the modal becomes visible. This property is useful for,
+e.g., implementing analytics events.
+
+<Canvas>
+  <Story
+    name="onOpen"
+    component={ConfirmationModal}
+    args={{
+      variant: 'blue',
+      open: true,
+      onClose: () => {},
+      onOpen: () => console.log('opened'),
+      title: 'Discard progress?',
+      body: 'Are you sure you want to discard your progress?',
+      primaryAction: () => {},
+      primaryActionCopy: 'Confirm',
+      secondaryActionCopy: 'Cancel',
+      linkBackTo: null,
+      linkBackCopy: null,
+    }}
+  >
+    {ConfirmationModalTemplate.bind()}
+  </Story>
+</Canvas>
+
+---
+
+<br />
+
+### Sandbox
+
+<Canvas>
+  <Story
+    name="Sandbox"
+    height="100px"
+  >
+  {ConfirmationModalTemplate.bind()}
+  </Story>
+</Canvas>
+
+<ArgsTable of={ConfirmationModal} story="Sandbox" />

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -27,7 +27,7 @@ export interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
   /* optional function called when modal is opened */
   onOpen?: () => void;
   /* modal header */
-  title: React.ReactNode;
+  title?: React.ReactNode;
   /* content between header and buttons */
   body: React.ReactNode;
   /* confirm action */
@@ -119,16 +119,19 @@ const ConfirmationModal = ({
           </IconButton>
         </Box>
         <Box sx={{ px: { xs: 3, sm: 4 }, mb: 7.5 }}>
-          {typeof title === 'string' ?
-            <Typography
-              variant={isMobile ? 'h2' : 'h1'}
-              weight="semibold"
-            >
-              {title}
-            </Typography> :
-            title
+          {title &&
+            <Box sx={{ mb: { xs: 3, sm: 4 } }}>
+              {typeof title === 'string' ?
+                <Typography
+                  variant={isMobile ? 'h2' : 'h1'}
+                  weight="semibold"
+                >
+                  {title}
+                </Typography> :
+                title
+              }
+            </Box>
           }
-          <Box sx={{ mt: { xs: 3, sm: 4 } }} />
           {typeof body === 'string' ?
             <Typography variant={isMobile ? 'p2' : 'p1'}>
               {body}

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import { DialogProps, Theme } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
+import CloseIcon from '@mui/icons-material/Close';
+import { Link } from 'react-router-dom';
+
+import Box from '../Box';
+import Button from '../Button';
+import IconButton from '../IconButton';
+import Typography from '../Typography';
+
+export type ConfirmationModalVariant =
+  | 'greyscale'
+  | 'blue'
+  | 'green'
+  | 'yellow'
+  | 'red';
+
+export interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
+  /* sets color of buttons */
+  variant?: ConfirmationModalVariant;
+  /* sets whether modal is open */
+  open: boolean;
+  /* function called when modal is closed */
+  onClose: () => void;
+  /* optional function called when modal is opened */
+  onOpen?: () => void;
+  /* modal header */
+  title: React.ReactNode;
+  /* content between header and buttons */
+  body: React.ReactNode;
+  /* confirm action */
+  primaryAction: () => void;
+  /* confirm action button copy */
+  primaryActionCopy: string;
+  /* cancel action button copy */
+  secondaryActionCopy: string;
+  /* action when user clicks link back */
+  linkBackTo?: string;
+  /* cancel action button copy */
+  linkBackCopy?: React.ReactNode;
+}
+
+
+const ConfirmationModal = ({
+  variant = 'blue',
+  open,
+  onClose,
+  onOpen = () => {},
+  title,
+  body,
+  primaryAction,
+  primaryActionCopy,
+  secondaryActionCopy,
+  linkBackTo,
+  linkBackCopy,
+  ...otherProps
+}: ConfirmationModalProps): JSX.Element => {
+  const isMobile = useMediaQuery((t: Theme) => t.breakpoints.down('md'));
+
+  useEffect(() => {
+    if (open) onOpen();
+  }, [open])
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          borderRadius: 8,
+        },
+      }}
+      {...otherProps}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          py: 3,
+          px: { xs: 2, sm: 3 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 4,
+          }}
+        >
+          {linkBackCopy && linkBackTo &&
+            <Button
+              component={Link}
+              variant="text"
+              color="blue"
+              to={linkBackTo}
+            >
+              {typeof linkBackCopy === 'string' ?
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    color: 'blue.500',
+                  }}
+                >
+                  <KeyboardArrowLeftIcon color="inherit" sx={{ fontSize: 22 }} />
+                  <Typography variant="p1" weight="medium">
+                    {linkBackCopy}
+                  </Typography>
+                </Box> :
+                linkBackCopy
+              }
+            </Button>
+          }
+          <IconButton onClick={onClose} sx={{ ml: 'auto' }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <Box sx={{ px: {xs: 0, sm: 4 }, mb: 7.5 }}>
+          {typeof title === 'string' ?
+            <Typography
+              variant={isMobile ? 'h2' : 'h1'}
+              weight="semibold"
+            >
+              {title}
+            </Typography> :
+            title
+          }
+          <Box sx={{ mt: {xs: 3, sm: 4 } }} />
+          {typeof body === 'string' ?
+            <Typography variant={isMobile ? 'p2' : 'p1'}>
+              {body}
+            </Typography> :
+            body
+          }
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            justifyContent: 'flex-end',
+          }}
+        >
+          <Button
+            color={variant}
+            variant="text"
+            onClick={onClose}
+            fullWidth={isMobile}
+            sx={{
+              mr: { xs: 0, sm: 2 },
+              mb: { xs: 1, sm: 0 },
+              // overrides styling on text buttons that prevents
+              // centering for full-width buttons
+              ml: 0,
+            }}
+          >
+            {secondaryActionCopy}
+          </Button>
+          <Button
+            color={variant}
+            variant="primary"
+            onClick={primaryAction}
+          >
+            {primaryActionCopy}
+          </Button>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+};
+
+export default ConfirmationModal;

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -80,7 +80,7 @@ const ConfirmationModal = ({
           display: 'flex',
           flexDirection: 'column',
           py: 3,
-          px: { xs: 2, sm: 3 },
+          mx: { xs: 2, sm: 3 },
         }}
       >
         <Box
@@ -118,7 +118,7 @@ const ConfirmationModal = ({
             <CloseIcon />
           </IconButton>
         </Box>
-        <Box sx={{ px: {xs: 0, sm: 4 }, mb: 7.5 }}>
+        <Box sx={{ px: { xs: 3, sm: 4 }, mb: 7.5 }}>
           {typeof title === 'string' ?
             <Typography
               variant={isMobile ? 'h2' : 'h1'}
@@ -128,7 +128,7 @@ const ConfirmationModal = ({
             </Typography> :
             title
           }
-          <Box sx={{ mt: {xs: 3, sm: 4 } }} />
+          <Box sx={{ mt: { xs: 3, sm: 4 } }} />
           {typeof body === 'string' ?
             <Typography variant={isMobile ? 'p2' : 'p1'}>
               {body}

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -4,7 +4,6 @@ import { DialogProps, Theme } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import CloseIcon from '@mui/icons-material/Close';
-import { Link } from 'react-router-dom';
 
 import Box from '../Box';
 import Button from '../Button';
@@ -38,7 +37,7 @@ export interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
   /* cancel action button copy */
   secondaryActionCopy: string;
   /* action when user clicks link back */
-  linkBackTo?: string;
+  linkBackAction?: () => void;
   /* cancel action button copy */
   linkBackCopy?: React.ReactNode;
 }
@@ -54,7 +53,7 @@ const ConfirmationModal = ({
   primaryAction,
   primaryActionCopy,
   secondaryActionCopy,
-  linkBackTo,
+  linkBackAction,
   linkBackCopy,
   ...otherProps
 }: ConfirmationModalProps): JSX.Element => {
@@ -73,6 +72,7 @@ const ConfirmationModal = ({
           borderRadius: 8,
         },
       }}
+      fullWidth
       {...otherProps}
     >
       <Box
@@ -91,12 +91,11 @@ const ConfirmationModal = ({
             mb: 4,
           }}
         >
-          {linkBackCopy && linkBackTo &&
+          {linkBackCopy && linkBackAction &&
             <Button
-              component={Link}
               variant="text"
               color="blue"
-              to={linkBackTo}
+              onClick={linkBackAction}
             >
               {typeof linkBackCopy === 'string' ?
                 <Box

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -24,9 +24,17 @@ export interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
   open: boolean;
   /* function called when modal is closed */
   onClose: () => void;
-  /* optional function called when modal is opened */
+  /**
+   * function called when modal is opened
+   * 
+   * @optional
+   */
   onOpen?: () => void;
-  /* modal header */
+  /**
+   * modal header
+   * 
+   * @optional
+   */
   title?: React.ReactNode;
   /* content between header and buttons */
   body: React.ReactNode;
@@ -36,9 +44,17 @@ export interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
   primaryActionCopy: string;
   /* cancel action button copy */
   secondaryActionCopy: string;
-  /* action when user clicks link back */
+  /**
+   * action when user clicks link back
+   * 
+   * @optional
+   */
   linkBackAction?: () => void;
-  /* cancel action button copy */
+  /**
+   * copy for link back
+   * 
+   * @optional
+   */
   linkBackCopy?: React.ReactNode;
 }
 

--- a/src/components/ConfirmationModal/index.ts
+++ b/src/components/ConfirmationModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ConfirmationModal';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,41 +1,44 @@
+export { default as Banner } from './Banner';
+export * from './Banner/Banner';
+
 export { default as Box } from './Box';
 export * from './Box/Box';
 
 export { default as Button } from './Button';
 export * from './Button/Button';
 
-export { default as IconButton } from './IconButton';
-export * from './IconButton/IconButton';
-
 export { default as Card } from './Card';
 export * from './Card/Card';
-
-export { default as CardHeader } from './CardHeader';
-export * from './CardHeader/CardHeader';
 
 export { default as CardContent } from './CardContent';
 export * from './CardContent/CardContent';
 
-export { default as Typography } from './Typography';
-export * from './Typography/Typography';
+export { default as CardHeader } from './CardHeader';
+export * from './CardHeader/CardHeader';
 
-export { default as LineItem } from './LineItem';
-export * from './LineItem/LineItem';
+export { default as ConfirmationModal } from './ConfirmationModal';
+export * from './ConfirmationModal/ConfirmationModal';
 
-export { default as InformationCard } from './InformationCard';
-export * from './InformationCard/InformationCard';
+export { default as DatePicker } from './Field/DatePickerField';
+export * from './Field/DatePickerField/DatePickerField';
 
-export { default as ImageGridItem } from './ImageGridItem';
-export * from './ImageGridItem/ImageGridItem';
+export { default as IconButton } from './IconButton';
+export * from './IconButton/IconButton';
 
 export { default as ImageGrid } from './ImageGrid';
 export * from './ImageGrid/ImageGrid';
 
-export { default as SuggestedAction } from './SuggestedAction';
-export * from './SuggestedAction/SuggestedAction';
+export { default as ImageGridItem } from './ImageGridItem';
+export * from './ImageGridItem/ImageGridItem';
 
-export { default as SuggestedActionAccordion } from './SuggestedActionAccordion';
-export * from './SuggestedActionAccordion/SuggestedActionAccordion';
+export { default as InformationCard } from './InformationCard';
+export * from './InformationCard/InformationCard';
+
+export { default as InlineNotification } from './InlineNotification';
+export * from './InlineNotification/InlineNotification';
+
+export { default as LineItem } from './LineItem';
+export * from './LineItem/LineItem';
 
 export { default as List } from './List';
 export * from './List/List';
@@ -43,14 +46,14 @@ export * from './List/List';
 export { default as ListItem } from './ListItem';
 export * from './ListItem/ListItem';
 
-export { default as InlineNotification } from './InlineNotification';
-export * from './InlineNotification/InlineNotification';
+export { default as SuggestedAction } from './SuggestedAction';
+export * from './SuggestedAction/SuggestedAction';
 
-export { default as Banner } from './Banner';
-export * from './Banner/Banner';
+export { default as SuggestedActionAccordion } from './SuggestedActionAccordion';
+export * from './SuggestedActionAccordion/SuggestedActionAccordion';
 
 export { default as TextField } from './Field/TextField';
 export * from './Field/TextField/TextField';
 
-export { default as DatePicker } from './Field/DatePickerField';
-export * from './Field/DatePickerField/DatePickerField';
+export { default as Typography } from './Typography';
+export * from './Typography/Typography';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   Banner,
   SuggestedAction,
   SuggestedActionAccordion,
+  ConfirmationModal,
 } from './components';
 import {
   darken,
@@ -73,4 +74,5 @@ export {
   alpha,
   SuggestedAction,
   SuggestedActionAccordion,
+  ConfirmationModal,
 };


### PR DESCRIPTION
Adds a confirmation modal to hajimari. Now that I take another look at the underlying ticket, I see that we intended to build this in izakaya, but given the frequency with which we use this paradigm, I think including it in hajimari makes sense, so I'm going to leave it for now.

One shortcoming due to hajimari: Because hajimari isn't wrapped in a `Router`, we can't use `react-router-dom`'s `Link` component as the component type for the optional text button in the upper left corner of the modal. Instead, I use an ordinary button, which isn't optimal for accessibility.

![Screen Shot 2022-06-27 at 3 21 14 PM](https://user-images.githubusercontent.com/67885346/176045468-dfdf253e-6773-4884-a676-513a6fd1faf5.png)

![Screen Shot 2022-06-27 at 3 28 25 PM](https://user-images.githubusercontent.com/67885346/176046596-4762230f-42f1-4936-8199-9d0621ecf260.png)
