### PR TITLE
add relative positioning to banner wrapper

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -66,6 +66,7 @@ const BannerRoot = styled('div', { name: 'BannerRoot' })(e_sx({
   backgroundColor: 'blue.100',
   display: 'flex',
   flexDirection: 'column',
+  position: 'relative',
 }));
 
 const Banner = ({


### PR DESCRIPTION
In placing a `Banner` with a close icon, I noticed that the close icon was not rendering. I traced this to the absolute positioning of the icon. Because the `Banner` container is not "positioned," the icon is positioned relative to the document body. Accordingly, this PR adds a `position` attribute (with a value of `relative`) to the `Banner` wrapper.