### PR TITLE
[ROK-848] Add additional props to SuggestedAction component

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -330,8 +330,10 @@ interface SuggestedActionProps {
     ctaAction: () => void;
     secondaryCta?: string;
     secondaryCtaAction?: () => void;
+    hideCtas?: boolean;
+    children?: React$1.ReactNode;
 }
-declare const SuggestedAction: ({ variant, description, onClickMenu, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, }: SuggestedActionProps) => JSX.Element;
+declare const SuggestedAction: ({ variant, description, onClickMenu, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, }: SuggestedActionProps) => JSX.Element;
 
 declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -25,6 +25,10 @@ export interface SuggestedActionProps {
   secondaryCta?: string;
   /* due date; optional */
   secondaryCtaAction?: () => void;
+  /* hide both ctas; optional */
+  hideCtas?: boolean;
+  /* any children components; optional */
+  children?: React.ReactNode;
 }
 
 const SuggestedAction = ({
@@ -36,6 +40,8 @@ const SuggestedAction = ({
   ctaAction,
   secondaryCta,
   secondaryCtaAction,
+  hideCtas,
+  children,
 }: SuggestedActionProps): JSX.Element => {
   const setBorderColor = (variant: SuggestedActionVariant): HajimariColor => {
     switch (variant) {
@@ -76,40 +82,46 @@ const SuggestedAction = ({
             pt: 0.5,
           }}
         >
-          {typeof description === 'string' ?
-            <Typography variant="p2">{description}</Typography> :
+          {typeof description === 'string' ? (
+            <Typography variant="p2">{description}</Typography>
+          ) : (
             description
-          }
+          )}
           <Box sx={{ mr: 3 }} />
           <IconButton onClick={onClickMenu}>
             <MoreVertIcon />
           </IconButton>
         </Box>
-        {dueDate &&
-          <Typography variant="p3" sx={{ mt: 1 }}>Due on {dueDate}</Typography>
-        }
-        <Box
-          sx={{
-            mt: 2.5,
-            display: 'flex',
-            width: 'fit-content',
-            flexWrap: { xs: 'wrap', sm: 'unset' },
-          }}
-        >
-          <Button variant="text" onClick={ctaAction} align="left">
-            {cta}
-          </Button>
-          {secondaryCta && secondaryCtaAction &&
-            <Button
-              variant="text"
-              onClick={secondaryCtaAction}
-              sx={{ ml: { xs: -2, sm: 0.5 } }}
-              align="left"
-            >
-              {secondaryCta}
+        {dueDate && (
+          <Typography variant="p3" sx={{ mt: 1 }}>
+            Due on {dueDate}
+          </Typography>
+        )}
+        {!hideCtas && (
+          <Box
+            sx={{
+              mt: 2.5,
+              display: 'flex',
+              width: 'fit-content',
+              flexWrap: { xs: 'wrap', sm: 'unset' },
+            }}
+          >
+            <Button variant="text" onClick={ctaAction} align="left">
+              {cta}
             </Button>
-          }
-        </Box>
+            {secondaryCta && secondaryCtaAction && (
+              <Button
+                variant="text"
+                onClick={secondaryCtaAction}
+                sx={{ ml: { xs: -2, sm: 0.5 } }}
+                align="left"
+              >
+                {secondaryCta}
+              </Button>
+            )}
+          </Box>
+        )}
+        {children}
       </Box>
     </Box>
   );

--- a/src/components/SuggestedAction/index.ts
+++ b/src/components/SuggestedAction/index.ts
@@ -1,1 +1,1 @@
-export { default } from './SuggestedAction';
+export { default, SuggestedActionProps } from './SuggestedAction';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -46,7 +46,10 @@ export * from './List/List';
 export { default as ListItem } from './ListItem';
 export * from './ListItem/ListItem';
 
-export { default as SuggestedAction } from './SuggestedAction';
+export {
+  default as SuggestedAction,
+  SuggestedActionProps,
+} from './SuggestedAction';
 export * from './SuggestedAction/SuggestedAction';
 
 export { default as SuggestedActionAccordion } from './SuggestedActionAccordion';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   Banner,
   SuggestedAction,
   SuggestedActionAccordion,
+  SuggestedActionProps,
   ConfirmationModal,
 } from './components';
 import {
@@ -77,6 +78,7 @@ export {
   hexValue,
   alpha,
   SuggestedAction,
+  SuggestedActionProps,
   SuggestedActionAccordion,
   ConfirmationModal,
 };


### PR DESCRIPTION
**Note: Needed for ROK-848**: https://gethearth.atlassian.net/browse/ROK-848

- Adds some additional optional props to `SuggestedAction` components:
  - `hideCtas` - removes cta controls from rendering
  - `children` - acts like the same prop for any other React component
- Exposes the `SuggestedActionProps` interface for use elsewhere
- Otherwise, Prettier changes