### PR TITLE
Menu component

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -358,14 +358,12 @@ interface SuggestedActionProps {
     secondaryCtaAction?: () => void;
     hideCtas?: boolean;
     children?: React$1.ReactNode;
-    hamburgerActionProps: {
-        workflow: string;
-        dismissAction: () => void;
-        viewWorkflow: () => void;
-        disableAction: () => void;
-    };
+    workflow: string;
+    dismissAction: () => void;
+    viewWorkflow: () => void;
+    disableAction: () => void;
 }
-declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, hamburgerActionProps, }: SuggestedActionProps) => JSX.Element;
+declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, workflow, viewWorkflow, disableAction, dismissAction, }: SuggestedActionProps) => JSX.Element;
 
 declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -351,7 +351,6 @@ declare type SuggestedActionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 interface SuggestedActionProps {
     variant: SuggestedActionVariant;
     description: React$1.ReactNode;
-    onClickMenu: () => void;
     dueDate?: string;
     cta: string;
     ctaAction: () => void;
@@ -360,7 +359,16 @@ interface SuggestedActionProps {
     hideCtas?: boolean;
     children?: React$1.ReactNode;
 }
-declare const SuggestedAction: ({ variant, description, onClickMenu, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, }: SuggestedActionProps) => JSX.Element;
+/**
+ *
+ * 1. View workflow details
+ *  /dashboard/clients/${homeownerId}/quote/${quoteId}
+ * 2. Dismiss
+ *  suggestedActionId
+ * 3. Don't show this again
+ * suggestedActionTypeID
+ */
+declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, }: SuggestedActionProps) => JSX.Element;
 
 declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {
@@ -413,18 +421,18 @@ interface MenuProps extends MenuProps$1 {
      * an HTML element that's used to set the position of the menu
      * @default undefined
      */
-    anchorEl: HTMLElement;
+    anchorEl: HTMLElement | null;
     /**
      * if true, menu is shown
      * @default undefined
      */
     open: boolean;
 }
-declare const Menu: ({ children, anchorEl, open }: MenuProps) => JSX.Element;
+declare const Menu: ({ children, anchorEl, open, ...props }: MenuProps) => JSX.Element;
 
 interface MenuTopContentProps {
     onClose?: (args?: any) => void;
-    title: string;
+    title?: string;
 }
 declare const MenuTopContent: ({ onClose, title }: MenuTopContentProps) => JSX.Element;
 

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -358,17 +358,11 @@ interface SuggestedActionProps {
     secondaryCtaAction?: () => void;
     hideCtas?: boolean;
     children?: React$1.ReactNode;
+    dismissAction?: () => void;
+    viewWorkflow?: () => void;
+    disableAction?: () => void;
 }
-/**
- *
- * 1. View workflow details
- *  /dashboard/clients/${homeownerId}/quote/${quoteId}
- * 2. Dismiss
- *  suggestedActionId
- * 3. Don't show this again
- * suggestedActionTypeID
- */
-declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, }: SuggestedActionProps) => JSX.Element;
+declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, dismissAction, viewWorkflow, disableAction, }: SuggestedActionProps) => JSX.Element;
 
 declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -358,9 +358,9 @@ interface SuggestedActionProps {
     secondaryCtaAction?: () => void;
     hideCtas?: boolean;
     children?: React$1.ReactNode;
-    dismissAction?: () => void;
-    viewWorkflow?: () => void;
-    disableAction?: () => void;
+    dismissAction: () => void;
+    viewWorkflow: () => void;
+    disableAction: () => void;
 }
 declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, dismissAction, viewWorkflow, disableAction, }: SuggestedActionProps) => JSX.Element;
 

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -6,8 +6,11 @@ import { LinkProps } from 'react-router-dom';
 import { CardProps as CardProps$1 } from '@mui/material/Card';
 import { CardContentProps as CardContentProps$1 } from '@mui/material/CardContent';
 import { CardHeaderProps as CardHeaderProps$1 } from '@mui/material/CardHeader';
-import { DialogProps, ListProps as ListProps$1, ListItemProps as ListItemProps$1 } from '@mui/material';
+import { DialogProps as DialogProps$1, DialogActionsProps, ListProps as ListProps$1, ListItemProps as ListItemProps$1, MenuProps as MenuProps$1 } from '@mui/material';
 import { TextFieldProps as TextFieldProps$1 } from '@mui/material/TextField';
+import { DialogProps as DialogProps$2 } from '@mui/material/Dialog';
+import { DialogContentProps as DialogContentProps$1 } from '@mui/material/DialogContent';
+import { DialogTitleProps } from '@mui/material/DialogTitle';
 import { IconButtonProps as IconButtonProps$1 } from '@mui/material/IconButton';
 import { ImageListProps } from '@mui/material/ImageList';
 import { ImageListItemProps } from '@mui/material/ImageListItem';
@@ -148,7 +151,7 @@ interface CardHeaderProps extends CardHeaderProps$1 {
 declare const CardHeader: ({ bottomDivider, children, bg, sx, ...otherProps }: CardHeaderProps) => JSX.Element;
 
 declare type ConfirmationModalVariant = 'greyscale' | 'blue' | 'green' | 'yellow' | 'red';
-interface ConfirmationModalProps extends Omit<DialogProps, 'title'> {
+interface ConfirmationModalProps extends Omit<DialogProps$1, 'title'> {
     variant?: ConfirmationModalVariant;
     open: boolean;
     onClose: () => void;
@@ -197,6 +200,30 @@ interface DatePickerProps {
     value?: string | Date | null;
 }
 declare const DatePickerField: ({ name, label, helperText, textFieldProps, onChangeCallback, onBlurCallback, error, value: initialValue, ...otherProps }: DatePickerProps) => JSX.Element;
+
+interface DialogProps extends DialogProps$2 {
+}
+declare const Dialog: ({ children, sx, ...props }: DialogProps) => JSX.Element;
+
+interface DialogActionProps extends DialogActionsProps {
+}
+declare const DialogActions: ({ children, sx, ...otherProps }: DialogActionProps) => JSX.Element;
+
+interface DialogContentProps extends DialogContentProps$1 {
+}
+declare const DialogContent: ({ children, ...otherProps }: DialogContentProps) => JSX.Element;
+
+interface DialogHeaderProps extends DialogTitleProps {
+}
+declare const DialogHeader: ({ children, ...props }: DialogHeaderProps) => JSX.Element;
+
+interface DialogTopContentProps extends DialogTitleProps {
+    showCloseButton: boolean;
+    backlink?: string;
+    backlinkAction?: () => void;
+    onClose?: () => void;
+}
+declare const DialogTopContent: ({ children, showCloseButton, onClose, backlink, backlinkAction, ...props }: DialogTopContentProps) => JSX.Element;
 
 declare type IconButtonProps = {
     /**
@@ -376,4 +403,29 @@ interface TypographyProps extends TypographyProps$1 {
 }
 declare const Typography: (props: TypographyProps) => JSX.Element;
 
-export { Banner, BannerProps, Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, ConfirmationModal, ConfirmationModalProps, ConfirmationModalVariant, DatePickerField as DatePicker, DatePickerField, DatePickerProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, List, ListItem, ListItemProps, ListProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionAccordion, SuggestedActionAccordionProps, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };
+interface MenuProps extends MenuProps$1 {
+    /**
+     * pass in menu items or buttons as children
+     * @default undefined
+     */
+    children: React$1.ReactNode;
+    /**
+     * an HTML element that's used to set the position of the menu
+     * @default undefined
+     */
+    anchorEl: HTMLElement;
+    /**
+     * if true, menu is shown
+     * @default undefined
+     */
+    open: boolean;
+}
+declare const Menu: ({ children, anchorEl, open }: MenuProps) => JSX.Element;
+
+interface MenuTopContentProps {
+    onClose?: (args?: any) => void;
+    title: string;
+}
+declare const MenuTopContent: ({ onClose, title }: MenuTopContentProps) => JSX.Element;
+
+export { Banner, BannerProps, Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, ConfirmationModal, ConfirmationModalProps, ConfirmationModalVariant, DatePickerField, DatePickerProps, Dialog, DialogActionProps, DialogActions, DialogContentProps, DialogContent as DialogContentText, DialogHeader, DialogHeaderProps, DialogProps, DialogTopContent, DialogTopContentProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, List, ListItem, ListItemProps, ListProps, Menu, MenuProps, MenuTopContent, MenuTopContentProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionAccordion, SuggestedActionAccordionProps, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -6,13 +6,7 @@ import { LinkProps } from 'react-router-dom';
 import { CardProps as CardProps$1 } from '@mui/material/Card';
 import { CardContentProps as CardContentProps$1 } from '@mui/material/CardContent';
 import { CardHeaderProps as CardHeaderProps$1 } from '@mui/material/CardHeader';
-import {
-  DialogProps as DialogProps$1,
-  DialogActionsProps,
-  ListProps as ListProps$1,
-  ListItemProps as ListItemProps$1,
-  MenuProps as MenuProps$1,
-} from '@mui/material';
+import { DialogProps as DialogProps$1, DialogActionsProps, ListProps as ListProps$1, ListItemProps as ListItemProps$1, MenuProps as MenuProps$1 } from '@mui/material';
 import { TextFieldProps as TextFieldProps$1 } from '@mui/material/TextField';
 import { DialogProps as DialogProps$2 } from '@mui/material/Dialog';
 import { DialogContentProps as DialogContentProps$1 } from '@mui/material/DialogContent';
@@ -23,927 +17,420 @@ import { ImageListItemProps } from '@mui/material/ImageListItem';
 import { AccordionProps } from '@mui/material/Accordion';
 import { TypographyProps as TypographyProps$1 } from '@mui/material/Typography';
 
-interface BoxProps extends BoxProps$1 {}
+interface BoxProps extends BoxProps$1 {
+}
 declare const Box: (props: BoxProps) => JSX.Element;
 
 interface BannerProps extends BoxProps {
-  /**
-   * the bolded title at the top of the banner
-   *
-   * @optional
-   * */
-  title?: string;
-  /** the description within the banner; the only required prop */
-  description: string;
-  /**
-   * determines whether the `InfoOutlinedIcon` appears to the left of the title
-   *
-   * @default false
-   */
-  showStartIcon?: boolean;
-  /**
-   * if defined, renders a `CloseIcon` at the top right of the banner, which
-   * will call the function passed to `onClose` on click
-   *
-   * @optional
-   */
-  onClose?: (args?: any) => void;
-  /**
-   * if defined in conjunction with `primaryActionLabel`, renders a primary
-   * `Button` for a primary action
-   *
-   * @optional
-   */
-  primaryAction?: (args?: any) => void;
-  /**
-   * `Button` label for the primary action
-   *
-   * @optional
-   */
-  primaryActionLabel?: string;
-  /**
-   * if defined in conjunction with `secondaryActionLabel`, renders a text
-   * `Button` for a secondary action
-   *
-   * @optional
-   */
-  secondaryAction?: (args?: any) => void;
-  /**
-   * `Button` label for the secondary action
-   *
-   * @optional
-   */
-  secondaryActionLabel?: string;
+    /**
+     * the bolded title at the top of the banner
+     *
+     * @optional
+     * */
+    title?: string;
+    /** the description within the banner; the only required prop */
+    description: string;
+    /**
+     * determines whether the `InfoOutlinedIcon` appears to the left of the title
+     *
+     * @default false
+    */
+    showStartIcon?: boolean;
+    /**
+     * if defined, renders a `CloseIcon` at the top right of the banner, which
+     * will call the function passed to `onClose` on click
+     *
+     * @optional
+     */
+    onClose?: (args?: any) => void;
+    /**
+     * if defined in conjunction with `primaryActionLabel`, renders a primary
+     * `Button` for a primary action
+     *
+     * @optional
+     */
+    primaryAction?: (args?: any) => void;
+    /**
+     * `Button` label for the primary action
+     *
+     * @optional
+     */
+    primaryActionLabel?: string;
+    /**
+     * if defined in conjunction with `secondaryActionLabel`, renders a text
+     * `Button` for a secondary action
+     *
+     * @optional
+     */
+    secondaryAction?: (args?: any) => void;
+    /**
+     * `Button` label for the secondary action
+     *
+     * @optional
+     */
+    secondaryActionLabel?: string;
 }
-declare const Banner: ({
-  title,
-  description,
-  showStartIcon,
-  onClose,
-  primaryAction,
-  primaryActionLabel,
-  secondaryAction,
-  secondaryActionLabel,
-}: BannerProps) => JSX.Element;
+declare const Banner: ({ title, description, showStartIcon, onClose, primaryAction, primaryActionLabel, secondaryAction, secondaryActionLabel, }: BannerProps) => JSX.Element;
 
 declare type HTMLAnchorProps = React$1.HTMLProps<HTMLAnchorElement>;
 interface ButtonProps<C = any> extends ButtonProps$1 {
-  /**
-   *
-   * This prop is only relevant for the `text` variant.
-   *
-   * The background type on which this Button is appears. Since we don't
-   * currently support light vs dark mode on web as a theme variant, we can
-   * use this prop to determine relevant styles.
-   *
-   * @default 'light'
-   */
-  bg?: BackgroundMode;
-  /**
-   * In order to use certain props that one would expect to have available on a button
-   * while satisfying typescript in accordance with MUI's component 'composition'
-   * rules, we have to do some forwardRef + generics shenanigans:
-   *
-   * https://mui.com/material-ui/guides/composition/#with-typescript
-   * https://github.com/mui/material-ui/issues/15827#issuecomment-809209533
-   *
-   */
-  component?: C | string;
-  to?: LinkProps['to'];
-  css?: any;
-  noStopPropagation?: boolean;
-  /**
-   * It appears there are some type limitations when it comes to passing in
-   * props that an HTML anchor element would accept as attributes; so for now,
-   * we'll manually declare these types so that they can be accessed.
-   */
-  download?: HTMLAnchorProps['download'];
-  target?: HTMLAnchorProps['target'];
-  rel?: HTMLAnchorProps['rel'];
-  /**
-   * If `true`, shows the button in a "loading state" with a circular progress indicator
-   * @default false
-   */
-  loading?: boolean;
-  /**
-   * Text to display in the button when `loading` is `true`.
-   * @default false
-   */
-  loadingIndicator?: string;
-  /**
-   *
-   * `text` buttons should have their content aligned to one side or the other, so that they
-   * are aligned vertically along the same access as content around them. We achieve this using
-   * negative margins. This prop lets us conditionally determine whether that alignment (and
-   * on the left or right.
-   *
-   * @default undefined
-   */
-  align?: 'left' | 'right';
+    /**
+     *
+     * This prop is only relevant for the `text` variant.
+     *
+     * The background type on which this Button is appears. Since we don't
+     * currently support light vs dark mode on web as a theme variant, we can
+     * use this prop to determine relevant styles.
+     *
+     * @default 'light'
+     */
+    bg?: BackgroundMode;
+    /**
+     * In order to use certain props that one would expect to have available on a button
+     * while satisfying typescript in accordance with MUI's component 'composition'
+     * rules, we have to do some forwardRef + generics shenanigans:
+     *
+     * https://mui.com/material-ui/guides/composition/#with-typescript
+     * https://github.com/mui/material-ui/issues/15827#issuecomment-809209533
+     *
+     */
+    component?: C | string;
+    to?: LinkProps['to'];
+    css?: any;
+    noStopPropagation?: boolean;
+    /**
+     * It appears there are some type limitations when it comes to passing in
+     * props that an HTML anchor element would accept as attributes; so for now,
+     * we'll manually declare these types so that they can be accessed.
+     */
+    download?: HTMLAnchorProps['download'];
+    target?: HTMLAnchorProps['target'];
+    rel?: HTMLAnchorProps['rel'];
+    /**
+     * If `true`, shows the button in a "loading state" with a circular progress indicator
+     * @default false
+     */
+    loading?: boolean;
+    /**
+     * Text to display in the button when `loading` is `true`.
+     * @default false
+     */
+    loadingIndicator?: string;
+    /**
+     *
+     * `text` buttons should have their content aligned to one side or the other, so that they
+     * are aligned vertically along the same access as content around them. We achieve this using
+     * negative margins. This prop lets us conditionally determine whether that alignment (and
+     * on the left or right.
+     *
+     * @default undefined
+     */
+    align?: 'left' | 'right';
 }
-declare const Button: React$1.ForwardRefExoticComponent<
-  Pick<
-    ButtonProps<React$1.ComponentType<any>>,
-    | 'className'
-    | 'style'
-    | 'classes'
-    | 'color'
-    | 'translate'
-    | 'form'
-    | 'slot'
-    | 'title'
-    | 'children'
-    | 'component'
-    | 'sx'
-    | 'key'
-    | 'defaultChecked'
-    | 'defaultValue'
-    | 'suppressContentEditableWarning'
-    | 'suppressHydrationWarning'
-    | 'accessKey'
-    | 'contentEditable'
-    | 'contextMenu'
-    | 'dir'
-    | 'draggable'
-    | 'hidden'
-    | 'id'
-    | 'lang'
-    | 'placeholder'
-    | 'spellCheck'
-    | 'tabIndex'
-    | 'radioGroup'
-    | 'role'
-    | 'about'
-    | 'datatype'
-    | 'inlist'
-    | 'prefix'
-    | 'property'
-    | 'resource'
-    | 'typeof'
-    | 'vocab'
-    | 'autoCapitalize'
-    | 'autoCorrect'
-    | 'autoSave'
-    | 'itemProp'
-    | 'itemScope'
-    | 'itemType'
-    | 'itemID'
-    | 'itemRef'
-    | 'results'
-    | 'security'
-    | 'unselectable'
-    | 'inputMode'
-    | 'is'
-    | 'aria-activedescendant'
-    | 'aria-atomic'
-    | 'aria-autocomplete'
-    | 'aria-busy'
-    | 'aria-checked'
-    | 'aria-colcount'
-    | 'aria-colindex'
-    | 'aria-colspan'
-    | 'aria-controls'
-    | 'aria-current'
-    | 'aria-describedby'
-    | 'aria-details'
-    | 'aria-disabled'
-    | 'aria-dropeffect'
-    | 'aria-errormessage'
-    | 'aria-expanded'
-    | 'aria-flowto'
-    | 'aria-grabbed'
-    | 'aria-haspopup'
-    | 'aria-hidden'
-    | 'aria-invalid'
-    | 'aria-keyshortcuts'
-    | 'aria-label'
-    | 'aria-labelledby'
-    | 'aria-level'
-    | 'aria-live'
-    | 'aria-modal'
-    | 'aria-multiline'
-    | 'aria-multiselectable'
-    | 'aria-orientation'
-    | 'aria-owns'
-    | 'aria-placeholder'
-    | 'aria-posinset'
-    | 'aria-pressed'
-    | 'aria-readonly'
-    | 'aria-relevant'
-    | 'aria-required'
-    | 'aria-roledescription'
-    | 'aria-rowcount'
-    | 'aria-rowindex'
-    | 'aria-rowspan'
-    | 'aria-selected'
-    | 'aria-setsize'
-    | 'aria-sort'
-    | 'aria-valuemax'
-    | 'aria-valuemin'
-    | 'aria-valuenow'
-    | 'aria-valuetext'
-    | 'dangerouslySetInnerHTML'
-    | 'onCopy'
-    | 'onCopyCapture'
-    | 'onCut'
-    | 'onCutCapture'
-    | 'onPaste'
-    | 'onPasteCapture'
-    | 'onCompositionEnd'
-    | 'onCompositionEndCapture'
-    | 'onCompositionStart'
-    | 'onCompositionStartCapture'
-    | 'onCompositionUpdate'
-    | 'onCompositionUpdateCapture'
-    | 'onFocus'
-    | 'onFocusCapture'
-    | 'onBlur'
-    | 'onBlurCapture'
-    | 'onChange'
-    | 'onChangeCapture'
-    | 'onBeforeInput'
-    | 'onBeforeInputCapture'
-    | 'onInput'
-    | 'onInputCapture'
-    | 'onReset'
-    | 'onResetCapture'
-    | 'onSubmit'
-    | 'onSubmitCapture'
-    | 'onInvalid'
-    | 'onInvalidCapture'
-    | 'onLoad'
-    | 'onLoadCapture'
-    | 'onError'
-    | 'onErrorCapture'
-    | 'onKeyDown'
-    | 'onKeyDownCapture'
-    | 'onKeyPress'
-    | 'onKeyPressCapture'
-    | 'onKeyUp'
-    | 'onKeyUpCapture'
-    | 'onAbort'
-    | 'onAbortCapture'
-    | 'onCanPlay'
-    | 'onCanPlayCapture'
-    | 'onCanPlayThrough'
-    | 'onCanPlayThroughCapture'
-    | 'onDurationChange'
-    | 'onDurationChangeCapture'
-    | 'onEmptied'
-    | 'onEmptiedCapture'
-    | 'onEncrypted'
-    | 'onEncryptedCapture'
-    | 'onEnded'
-    | 'onEndedCapture'
-    | 'onLoadedData'
-    | 'onLoadedDataCapture'
-    | 'onLoadedMetadata'
-    | 'onLoadedMetadataCapture'
-    | 'onLoadStart'
-    | 'onLoadStartCapture'
-    | 'onPause'
-    | 'onPauseCapture'
-    | 'onPlay'
-    | 'onPlayCapture'
-    | 'onPlaying'
-    | 'onPlayingCapture'
-    | 'onProgress'
-    | 'onProgressCapture'
-    | 'onRateChange'
-    | 'onRateChangeCapture'
-    | 'onSeeked'
-    | 'onSeekedCapture'
-    | 'onSeeking'
-    | 'onSeekingCapture'
-    | 'onStalled'
-    | 'onStalledCapture'
-    | 'onSuspend'
-    | 'onSuspendCapture'
-    | 'onTimeUpdate'
-    | 'onTimeUpdateCapture'
-    | 'onVolumeChange'
-    | 'onVolumeChangeCapture'
-    | 'onWaiting'
-    | 'onWaitingCapture'
-    | 'onAuxClick'
-    | 'onAuxClickCapture'
-    | 'onClick'
-    | 'onClickCapture'
-    | 'onContextMenu'
-    | 'onContextMenuCapture'
-    | 'onDoubleClick'
-    | 'onDoubleClickCapture'
-    | 'onDrag'
-    | 'onDragCapture'
-    | 'onDragEnd'
-    | 'onDragEndCapture'
-    | 'onDragEnter'
-    | 'onDragEnterCapture'
-    | 'onDragExit'
-    | 'onDragExitCapture'
-    | 'onDragLeave'
-    | 'onDragLeaveCapture'
-    | 'onDragOver'
-    | 'onDragOverCapture'
-    | 'onDragStart'
-    | 'onDragStartCapture'
-    | 'onDrop'
-    | 'onDropCapture'
-    | 'onMouseDown'
-    | 'onMouseDownCapture'
-    | 'onMouseEnter'
-    | 'onMouseLeave'
-    | 'onMouseMove'
-    | 'onMouseMoveCapture'
-    | 'onMouseOut'
-    | 'onMouseOutCapture'
-    | 'onMouseOver'
-    | 'onMouseOverCapture'
-    | 'onMouseUp'
-    | 'onMouseUpCapture'
-    | 'onSelect'
-    | 'onSelectCapture'
-    | 'onTouchCancel'
-    | 'onTouchCancelCapture'
-    | 'onTouchEnd'
-    | 'onTouchEndCapture'
-    | 'onTouchMove'
-    | 'onTouchMoveCapture'
-    | 'onTouchStart'
-    | 'onTouchStartCapture'
-    | 'onPointerDown'
-    | 'onPointerDownCapture'
-    | 'onPointerMove'
-    | 'onPointerMoveCapture'
-    | 'onPointerUp'
-    | 'onPointerUpCapture'
-    | 'onPointerCancel'
-    | 'onPointerCancelCapture'
-    | 'onPointerEnter'
-    | 'onPointerEnterCapture'
-    | 'onPointerLeave'
-    | 'onPointerLeaveCapture'
-    | 'onPointerOver'
-    | 'onPointerOverCapture'
-    | 'onPointerOut'
-    | 'onPointerOutCapture'
-    | 'onGotPointerCapture'
-    | 'onGotPointerCaptureCapture'
-    | 'onLostPointerCapture'
-    | 'onLostPointerCaptureCapture'
-    | 'onScroll'
-    | 'onScrollCapture'
-    | 'onWheel'
-    | 'onWheelCapture'
-    | 'onAnimationStart'
-    | 'onAnimationStartCapture'
-    | 'onAnimationEnd'
-    | 'onAnimationEndCapture'
-    | 'onAnimationIteration'
-    | 'onAnimationIterationCapture'
-    | 'onTransitionEnd'
-    | 'onTransitionEndCapture'
-    | 'css'
-    | 'size'
-    | 'disabled'
-    | 'name'
-    | 'target'
-    | 'type'
-    | 'href'
-    | 'to'
-    | 'download'
-    | 'rel'
-    | 'autoFocus'
-    | 'formAction'
-    | 'formEncType'
-    | 'formMethod'
-    | 'formNoValidate'
-    | 'formTarget'
-    | 'value'
-    | 'action'
-    | 'loading'
-    | 'align'
-    | 'fullWidth'
-    | 'disableElevation'
-    | 'startIcon'
-    | 'endIcon'
-    | 'variant'
-    | 'centerRipple'
-    | 'disableRipple'
-    | 'disableTouchRipple'
-    | 'focusRipple'
-    | 'focusVisibleClassName'
-    | 'LinkComponent'
-    | 'onFocusVisible'
-    | 'TouchRippleProps'
-    | 'touchRippleRef'
-    | 'disableFocusRipple'
-    | 'bg'
-    | 'noStopPropagation'
-    | 'loadingIndicator'
-  > &
-    React$1.RefAttributes<HTMLButtonElement>
->;
+declare const Button: React$1.ForwardRefExoticComponent<Pick<ButtonProps<React$1.ComponentType<any>>, "className" | "style" | "classes" | "color" | "translate" | "form" | "slot" | "title" | "children" | "component" | "sx" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | "accessKey" | "contentEditable" | "contextMenu" | "dir" | "draggable" | "hidden" | "id" | "lang" | "placeholder" | "spellCheck" | "tabIndex" | "radioGroup" | "role" | "about" | "datatype" | "inlist" | "prefix" | "property" | "resource" | "typeof" | "vocab" | "autoCapitalize" | "autoCorrect" | "autoSave" | "itemProp" | "itemScope" | "itemType" | "itemID" | "itemRef" | "results" | "security" | "unselectable" | "inputMode" | "is" | "aria-activedescendant" | "aria-atomic" | "aria-autocomplete" | "aria-busy" | "aria-checked" | "aria-colcount" | "aria-colindex" | "aria-colspan" | "aria-controls" | "aria-current" | "aria-describedby" | "aria-details" | "aria-disabled" | "aria-dropeffect" | "aria-errormessage" | "aria-expanded" | "aria-flowto" | "aria-grabbed" | "aria-haspopup" | "aria-hidden" | "aria-invalid" | "aria-keyshortcuts" | "aria-label" | "aria-labelledby" | "aria-level" | "aria-live" | "aria-modal" | "aria-multiline" | "aria-multiselectable" | "aria-orientation" | "aria-owns" | "aria-placeholder" | "aria-posinset" | "aria-pressed" | "aria-readonly" | "aria-relevant" | "aria-required" | "aria-roledescription" | "aria-rowcount" | "aria-rowindex" | "aria-rowspan" | "aria-selected" | "aria-setsize" | "aria-sort" | "aria-valuemax" | "aria-valuemin" | "aria-valuenow" | "aria-valuetext" | "dangerouslySetInnerHTML" | "onCopy" | "onCopyCapture" | "onCut" | "onCutCapture" | "onPaste" | "onPasteCapture" | "onCompositionEnd" | "onCompositionEndCapture" | "onCompositionStart" | "onCompositionStartCapture" | "onCompositionUpdate" | "onCompositionUpdateCapture" | "onFocus" | "onFocusCapture" | "onBlur" | "onBlurCapture" | "onChange" | "onChangeCapture" | "onBeforeInput" | "onBeforeInputCapture" | "onInput" | "onInputCapture" | "onReset" | "onResetCapture" | "onSubmit" | "onSubmitCapture" | "onInvalid" | "onInvalidCapture" | "onLoad" | "onLoadCapture" | "onError" | "onErrorCapture" | "onKeyDown" | "onKeyDownCapture" | "onKeyPress" | "onKeyPressCapture" | "onKeyUp" | "onKeyUpCapture" | "onAbort" | "onAbortCapture" | "onCanPlay" | "onCanPlayCapture" | "onCanPlayThrough" | "onCanPlayThroughCapture" | "onDurationChange" | "onDurationChangeCapture" | "onEmptied" | "onEmptiedCapture" | "onEncrypted" | "onEncryptedCapture" | "onEnded" | "onEndedCapture" | "onLoadedData" | "onLoadedDataCapture" | "onLoadedMetadata" | "onLoadedMetadataCapture" | "onLoadStart" | "onLoadStartCapture" | "onPause" | "onPauseCapture" | "onPlay" | "onPlayCapture" | "onPlaying" | "onPlayingCapture" | "onProgress" | "onProgressCapture" | "onRateChange" | "onRateChangeCapture" | "onSeeked" | "onSeekedCapture" | "onSeeking" | "onSeekingCapture" | "onStalled" | "onStalledCapture" | "onSuspend" | "onSuspendCapture" | "onTimeUpdate" | "onTimeUpdateCapture" | "onVolumeChange" | "onVolumeChangeCapture" | "onWaiting" | "onWaitingCapture" | "onAuxClick" | "onAuxClickCapture" | "onClick" | "onClickCapture" | "onContextMenu" | "onContextMenuCapture" | "onDoubleClick" | "onDoubleClickCapture" | "onDrag" | "onDragCapture" | "onDragEnd" | "onDragEndCapture" | "onDragEnter" | "onDragEnterCapture" | "onDragExit" | "onDragExitCapture" | "onDragLeave" | "onDragLeaveCapture" | "onDragOver" | "onDragOverCapture" | "onDragStart" | "onDragStartCapture" | "onDrop" | "onDropCapture" | "onMouseDown" | "onMouseDownCapture" | "onMouseEnter" | "onMouseLeave" | "onMouseMove" | "onMouseMoveCapture" | "onMouseOut" | "onMouseOutCapture" | "onMouseOver" | "onMouseOverCapture" | "onMouseUp" | "onMouseUpCapture" | "onSelect" | "onSelectCapture" | "onTouchCancel" | "onTouchCancelCapture" | "onTouchEnd" | "onTouchEndCapture" | "onTouchMove" | "onTouchMoveCapture" | "onTouchStart" | "onTouchStartCapture" | "onPointerDown" | "onPointerDownCapture" | "onPointerMove" | "onPointerMoveCapture" | "onPointerUp" | "onPointerUpCapture" | "onPointerCancel" | "onPointerCancelCapture" | "onPointerEnter" | "onPointerEnterCapture" | "onPointerLeave" | "onPointerLeaveCapture" | "onPointerOver" | "onPointerOverCapture" | "onPointerOut" | "onPointerOutCapture" | "onGotPointerCapture" | "onGotPointerCaptureCapture" | "onLostPointerCapture" | "onLostPointerCaptureCapture" | "onScroll" | "onScrollCapture" | "onWheel" | "onWheelCapture" | "onAnimationStart" | "onAnimationStartCapture" | "onAnimationEnd" | "onAnimationEndCapture" | "onAnimationIteration" | "onAnimationIterationCapture" | "onTransitionEnd" | "onTransitionEndCapture" | "css" | "size" | "disabled" | "name" | "target" | "type" | "href" | "to" | "download" | "rel" | "autoFocus" | "formAction" | "formEncType" | "formMethod" | "formNoValidate" | "formTarget" | "value" | "action" | "loading" | "align" | "fullWidth" | "disableElevation" | "startIcon" | "endIcon" | "variant" | "centerRipple" | "disableRipple" | "disableTouchRipple" | "focusRipple" | "focusVisibleClassName" | "LinkComponent" | "onFocusVisible" | "TouchRippleProps" | "touchRippleRef" | "disableFocusRipple" | "bg" | "noStopPropagation" | "loadingIndicator"> & React$1.RefAttributes<HTMLButtonElement>>;
 
 interface CardColorProperty {
-  border?: CommonColor;
-  bg?: CommonColor;
+    border?: CommonColor;
+    bg?: CommonColor;
 }
-interface CardProps extends CardProps$1, CardColorProperty {}
-declare const Card: ({
-  border,
-  children,
-  bg,
-  sx,
-  ...props
-}: CardProps) => JSX.Element;
+interface CardProps extends CardProps$1, CardColorProperty {
+}
+declare const Card: ({ border, children, bg, sx, ...props }: CardProps) => JSX.Element;
 
 interface CardContentProps extends CardContentProps$1 {
-  border?: CommonColor;
-  bg?: CommonColor;
+    border?: CommonColor;
+    bg?: CommonColor;
 }
-declare const CardContent: ({
-  children,
-  bg,
-  ...props
-}: CardContentProps) => JSX.Element;
+declare const CardContent: ({ children, bg, ...props }: CardContentProps) => JSX.Element;
 
 interface CardHeaderProps extends CardHeaderProps$1 {
-  bottomDivider?: boolean;
-  border?: CommonColor;
-  bg?: CommonColor;
+    bottomDivider?: boolean;
+    border?: CommonColor;
+    bg?: CommonColor;
 }
-declare const CardHeader: ({
-  bottomDivider,
-  children,
-  bg,
-  sx,
-  ...otherProps
-}: CardHeaderProps) => JSX.Element;
+declare const CardHeader: ({ bottomDivider, children, bg, sx, ...otherProps }: CardHeaderProps) => JSX.Element;
 
-declare type ConfirmationModalVariant =
-  | 'greyscale'
-  | 'blue'
-  | 'green'
-  | 'yellow'
-  | 'red';
+declare type ConfirmationModalVariant = 'greyscale' | 'blue' | 'green' | 'yellow' | 'red';
 interface ConfirmationModalProps extends Omit<DialogProps$1, 'title'> {
-  variant?: ConfirmationModalVariant;
-  open: boolean;
-  onClose: () => void;
-  /**
-   * function called when modal is opened
-   *
-   * @optional
-   */
-  onOpen?: () => void;
-  /**
-   * modal header
-   *
-   * @optional
-   */
-  title?: React$1.ReactNode;
-  body: React$1.ReactNode;
-  primaryAction: () => void;
-  primaryActionCopy: string;
-  secondaryActionCopy: string;
-  /**
-   * action when user clicks link back
-   *
-   * @optional
-   */
-  linkBackAction?: () => void;
-  /**
-   * copy for link back
-   *
-   * @optional
-   */
-  linkBackCopy?: React$1.ReactNode;
+    variant?: ConfirmationModalVariant;
+    open: boolean;
+    onClose: () => void;
+    /**
+     * function called when modal is opened
+     *
+     * @optional
+     */
+    onOpen?: () => void;
+    /**
+     * modal header
+     *
+     * @optional
+     */
+    title?: React$1.ReactNode;
+    body: React$1.ReactNode;
+    primaryAction: () => void;
+    primaryActionCopy: string;
+    secondaryActionCopy: string;
+    /**
+     * action when user clicks link back
+     *
+     * @optional
+     */
+    linkBackAction?: () => void;
+    /**
+     * copy for link back
+     *
+     * @optional
+     */
+    linkBackCopy?: React$1.ReactNode;
 }
-declare const ConfirmationModal: ({
-  variant,
-  open,
-  onClose,
-  onOpen,
-  title,
-  body,
-  primaryAction,
-  primaryActionCopy,
-  secondaryActionCopy,
-  linkBackAction,
-  linkBackCopy,
-  ...otherProps
-}: ConfirmationModalProps) => JSX.Element;
+declare const ConfirmationModal: ({ variant, open, onClose, onOpen, title, body, primaryAction, primaryActionCopy, secondaryActionCopy, linkBackAction, linkBackCopy, ...otherProps }: ConfirmationModalProps) => JSX.Element;
 
 interface DatePickerProps {
-  name: string;
-  label?: string;
-  helperText?: string;
-  textFieldProps?: Partial<TextFieldProps$1>;
-  error?: string;
-  onChangeCallback?: (
-    date: any,
-    keyboardInputValue?: string | undefined
-  ) => void;
-  onBlurCallback?: () => void;
-  minDate?: Date | string;
-  maxDate?: Date | string;
-  disabled?: boolean;
-  value?: string | Date | null;
+    name: string;
+    label?: string;
+    helperText?: string;
+    textFieldProps?: Partial<TextFieldProps$1>;
+    error?: string;
+    onChangeCallback?: (date: any, keyboardInputValue?: string | undefined) => void;
+    onBlurCallback?: () => void;
+    minDate?: Date | string;
+    maxDate?: Date | string;
+    disabled?: boolean;
+    value?: string | Date | null;
 }
-declare const DatePickerField: ({
-  name,
-  label,
-  helperText,
-  textFieldProps,
-  onChangeCallback,
-  onBlurCallback,
-  error,
-  value: initialValue,
-  ...otherProps
-}: DatePickerProps) => JSX.Element;
+declare const DatePickerField: ({ name, label, helperText, textFieldProps, onChangeCallback, onBlurCallback, error, value: initialValue, ...otherProps }: DatePickerProps) => JSX.Element;
 
-interface DialogProps extends DialogProps$2 {}
+interface DialogProps extends DialogProps$2 {
+}
 declare const Dialog: ({ children, sx, ...props }: DialogProps) => JSX.Element;
 
-interface DialogActionProps extends DialogActionsProps {}
-declare const DialogActions: ({
-  children,
-  sx,
-  ...otherProps
-}: DialogActionProps) => JSX.Element;
+interface DialogActionProps extends DialogActionsProps {
+}
+declare const DialogActions: ({ children, sx, ...otherProps }: DialogActionProps) => JSX.Element;
 
-interface DialogContentProps extends DialogContentProps$1 {}
-declare const DialogContent: ({
-  children,
-  ...otherProps
-}: DialogContentProps) => JSX.Element;
+interface DialogContentProps extends DialogContentProps$1 {
+}
+declare const DialogContent: ({ children, ...otherProps }: DialogContentProps) => JSX.Element;
 
-interface DialogHeaderProps extends DialogTitleProps {}
-declare const DialogHeader: ({
-  children,
-  ...props
-}: DialogHeaderProps) => JSX.Element;
+interface DialogHeaderProps extends DialogTitleProps {
+}
+declare const DialogHeader: ({ children, ...props }: DialogHeaderProps) => JSX.Element;
 
 interface DialogTopContentProps extends DialogTitleProps {
-  showCloseButton: boolean;
-  backlink?: string;
-  backlinkAction?: () => void;
-  onClose?: () => void;
+    showCloseButton: boolean;
+    backlink?: string;
+    backlinkAction?: () => void;
+    onClose?: () => void;
 }
-declare const DialogTopContent: ({
-  children,
-  showCloseButton,
-  onClose,
-  backlink,
-  backlinkAction,
-  ...props
-}: DialogTopContentProps) => JSX.Element;
+declare const DialogTopContent: ({ children, showCloseButton, onClose, backlink, backlinkAction, ...props }: DialogTopContentProps) => JSX.Element;
 
 declare type IconButtonProps = {
-  /**
-   * The background type that this IconButton is appearing on. Since we don't
-   * currently support light vs dark mode on web as a theme variant, we can
-   * use this prop to determine relevant styles.
-   *
-   * @default 'light'
-   */
-  bg?: BackgroundMode;
+    /**
+     * The background type that this IconButton is appearing on. Since we don't
+     * currently support light vs dark mode on web as a theme variant, we can
+     * use this prop to determine relevant styles.
+     *
+     * @default 'light'
+     */
+    bg?: BackgroundMode;
 } & IconButtonProps$1;
 declare const IconButton: (props: IconButtonProps) => JSX.Element;
 
-interface ImageGridProps extends ImageListProps {}
-declare const ImageGrid: ({
-  children,
-  ...props
-}: ImageGridProps) => JSX.Element;
+interface ImageGridProps extends ImageListProps {
+}
+declare const ImageGrid: ({ children, ...props }: ImageGridProps) => JSX.Element;
 
 interface ImageItem {
-  /**
-   * The source string of an image, accepts the same values as the src prop
-   * of a the standard HTML img element
-   */
-  src: string;
-  /**
-   * A useful description of the image
-   */
-  alt: string;
+    /**
+     * The source string of an image, accepts the same values as the src prop
+     * of a the standard HTML img element
+     */
+    src: string;
+    /**
+     * A useful description of the image
+     */
+    alt: string;
 }
 interface ImageGridItemProps extends ImageListItemProps {
-  src: ImageItem['src'];
-  alt: ImageItem['alt'];
-  action?: React.ReactNode;
+    src: ImageItem['src'];
+    alt: ImageItem['alt'];
+    action?: React.ReactNode;
 }
-declare const ImageGridItem: ({
-  src,
-  alt,
-  action,
-  ...props
-}: ImageGridItemProps) => JSX.Element;
+declare const ImageGridItem: ({ src, alt, action, ...props }: ImageGridItemProps) => JSX.Element;
 
 interface InformationCardProps {
-  title: string;
-  children: React.ReactNode;
+    title: string;
+    children: React.ReactNode;
 }
-declare const InformationCard: ({
-  title,
-  children,
-}: InformationCardProps) => JSX.Element;
+declare const InformationCard: ({ title, children }: InformationCardProps) => JSX.Element;
 
 declare enum NotificationVariant {
-  info = 'info',
-  warning = 'warning',
-  success = 'success',
-  error = 'error',
+    info = "info",
+    warning = "warning",
+    success = "success",
+    error = "error"
 }
 interface InlineNotificationProps extends BoxProps {
-  /**
-   * Inline notifications are constrained to `info`, `warning`, `success`, or `error`.
-   * Since the default value is `info`, the default component will have styles
-   * related to that variant.
-   * @default `info`
-   */
-  variant?: NotificationVariant;
-  onClose?: (args?: any) => void;
-  /**
-   *
-   * @default false
-   */
-  showStartIcon?: boolean;
-  /**
-   * @optional function to do some kind of action
-   */
-  action?: (args?: any) => void;
-  /**
-   * the text of the actual button. If an `action` is provided without an `actionLabel`,
-   * a standalone arrow icon will appear as the CTA
-   *
-   * @default undefined
-   *  */
-  actionLabel?: string;
+    /**
+     * Inline notifications are constrained to `info`, `warning`, `success`, or `error`.
+     * Since the default value is `info`, the default component will have styles
+     * related to that variant.
+     * @default `info`
+     */
+    variant?: NotificationVariant;
+    onClose?: (args?: any) => void;
+    /**
+     *
+     * @default false
+     */
+    showStartIcon?: boolean;
+    /**
+     * @optional function to do some kind of action
+     */
+    action?: (args?: any) => void;
+    /**
+     * the text of the actual button. If an `action` is provided without an `actionLabel`,
+     * a standalone arrow icon will appear as the CTA
+     *
+     * @default undefined
+     *  */
+    actionLabel?: string;
 }
-declare const InlineNotification: ({
-  children,
-  variant,
-  onClose,
-  showStartIcon,
-  action,
-  actionLabel,
-  ...props
-}: InlineNotificationProps) => JSX.Element;
+declare const InlineNotification: ({ children, variant, onClose, showStartIcon, action, actionLabel, ...props }: InlineNotificationProps) => JSX.Element;
 
 interface LineItemProps {
-  leftContent: React$1.ReactNode;
-  rightContent: React$1.ReactNode;
-  width?: number | string;
+    leftContent: React$1.ReactNode;
+    rightContent: React$1.ReactNode;
+    width?: number | string;
 }
-declare const LineItem: ({
-  leftContent,
-  rightContent,
-  width,
-}: LineItemProps) => JSX.Element;
+declare const LineItem: ({ leftContent, rightContent, width, }: LineItemProps) => JSX.Element;
 
 interface ListProps extends ListProps$1 {
-  /**
-   * pass in list items as children
-   * @default undefined
-   */
-  children: React$1.ReactNode;
-  /**
-   * if a hajimari color is specified, the list will have a border
-   * @default undefined
-   */
-  border?: HajimariColor;
+    /**
+     * pass in list items as children
+     * @default undefined
+     */
+    children: React$1.ReactNode;
+    /**
+     * if a hajimari color is specified, the list will have a border
+     * @default undefined
+     */
+    border?: HajimariColor;
 }
 declare const List: ({ children, border }: ListProps) => JSX.Element;
 
 interface ListItemProps extends ListItemProps$1 {
-  /**
-   * The main text of list item row
-   * @default undefined
-   * @optional
-   */
-  headerText?: string;
-  /**
-   * a sorta subheader or more text to supplement main header
-   * @optional
-   */
-  description?: string;
-  /**
-   * primary actions are passed in as children. current use cases include button, toggle, and expand.
-   * if no children is passed in, list item will display text row.
-   * @optional
-   */
-  children?: React$1.ReactNode;
-  /**
-   * if true, headerText will be bolded
-   * @optional
-   * @default false
-   */
-  isHeader?: boolean;
+    /**
+     * The main text of list item row
+     * @default undefined
+     * @optional
+     */
+    headerText?: string;
+    /**
+     * a sorta subheader or more text to supplement main header
+     * @optional
+     */
+    description?: string;
+    /**
+     * primary actions are passed in as children. current use cases include button, toggle, and expand.
+     * if no children is passed in, list item will display text row.
+     * @optional
+     */
+    children?: React$1.ReactNode;
+    /**
+     * if true, headerText will be bolded
+     * @optional
+     * @default false
+     */
+    isHeader?: boolean;
 }
-declare const ListItem: ({
-  headerText,
-  description,
-  children,
-  divider,
-  isHeader,
-}: ListItemProps) => JSX.Element;
+declare const ListItem: ({ headerText, description, children, divider, isHeader, }: ListItemProps) => JSX.Element;
 
 declare type SuggestedActionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 interface SuggestedActionProps {
-  variant: SuggestedActionVariant;
-  description: React$1.ReactNode;
-  dueDate?: string;
-  cta: string;
-  ctaAction: () => void;
-  secondaryCta?: string;
-  secondaryCtaAction?: () => void;
-  hideCtas?: boolean;
-  children?: React$1.ReactNode;
-  dismissAction: () => void;
-  viewWorkflow: () => void;
-  disableAction: () => void;
+    variant: SuggestedActionVariant;
+    description: React$1.ReactNode;
+    dueDate?: string;
+    cta: string;
+    ctaAction: () => void;
+    secondaryCta?: string;
+    secondaryCtaAction?: () => void;
+    hideCtas?: boolean;
+    children?: React$1.ReactNode;
+    hamburgerActionProps: {
+        workflow: string;
+        dismissAction: () => void;
+        viewWorkflow: () => void;
+        disableAction: () => void;
+    };
 }
-declare const SuggestedAction: ({
-  variant,
-  description,
-  dueDate,
-  cta,
-  ctaAction,
-  secondaryCta,
-  secondaryCtaAction,
-  hideCtas,
-  children,
-  dismissAction,
-  viewWorkflow,
-  disableAction,
-}: SuggestedActionProps) => JSX.Element;
+declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, hamburgerActionProps, }: SuggestedActionProps) => JSX.Element;
 
-declare type SuggestedActionAccordionVariant =
-  | 'green'
-  | 'yellow'
-  | 'red'
-  | 'greyscale';
-interface SuggestedActionAccordionProps
-  extends Omit<AccordionProps, 'variant'> {
-  variant: SuggestedActionAccordionVariant;
-  groupTitle: string;
-  numItems: number;
-  highlightNumber?: boolean;
+declare type SuggestedActionAccordionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
+interface SuggestedActionAccordionProps extends Omit<AccordionProps, 'variant'> {
+    variant: SuggestedActionAccordionVariant;
+    groupTitle: string;
+    numItems: number;
+    highlightNumber?: boolean;
 }
-declare const SuggestedActionAccordion: ({
-  variant,
-  groupTitle,
-  numItems,
-  highlightNumber,
-  children,
-  ...otherProps
-}: SuggestedActionAccordionProps) => JSX.Element;
+declare const SuggestedActionAccordion: ({ variant, groupTitle, numItems, highlightNumber, children, ...otherProps }: SuggestedActionAccordionProps) => JSX.Element;
 
-declare type Mask =
-  | 'money'
-  | 'moneyWithCents'
-  | 'ssn'
-  | 'lastFourSsn'
-  | 'bankNumber'
-  | 'phone'
-  | 'percent'
-  | 'taxId'
-  | 'year'
-  | 'default'
-  | 'search'
-  | 'date';
+declare type Mask = 'money' | 'moneyWithCents' | 'ssn' | 'lastFourSsn' | 'bankNumber' | 'phone' | 'percent' | 'taxId' | 'year' | 'default' | 'search' | 'date';
 
 declare type TextFieldProps = {
-  mask: Mask;
-  value?: string;
+    mask: Mask;
+    value?: string;
 } & TextFieldProps$1;
-declare const TextField: ({
-  mask,
-  value,
-  onChange,
-  ...otherProps
-}: TextFieldProps) => JSX.Element;
+declare const TextField: ({ mask, value, onChange, ...otherProps }: TextFieldProps) => JSX.Element;
 
 declare const StatefulTextField: (props: TextFieldProps) => JSX.Element;
 
 declare type FontWeightVariant = 'regular' | 'medium' | 'semibold';
 declare type FontWeightValue = 400 | 500 | 600;
 declare type FontWeight = {
-  [w in FontWeightVariant]: FontWeightValue;
+    [w in FontWeightVariant]: FontWeightValue;
 };
 declare const fontWeights: FontWeight;
 interface TypographyProps extends TypographyProps$1 {
-  /**
-   * @default 'regular'
-   */
-  weight?: FontWeightVariant;
-  /**
-   * When using MUI in combination with styled/emotion, we lose access
-   * to the component prop. This appears to be a limitation of Typescript;
-   * doing this is a workaround:
-   *
-   * https://github.com/mui/material-ui/issues/15695#issuecomment-1026602904
-   */
-  component?: React$1.ElementType;
+    /**
+     * @default 'regular'
+     */
+    weight?: FontWeightVariant;
+    /**
+     * When using MUI in combination with styled/emotion, we lose access
+     * to the component prop. This appears to be a limitation of Typescript;
+     * doing this is a workaround:
+     *
+     * https://github.com/mui/material-ui/issues/15695#issuecomment-1026602904
+     */
+    component?: React$1.ElementType;
 }
 declare const Typography: (props: TypographyProps) => JSX.Element;
 
 interface MenuProps extends MenuProps$1 {
-  /**
-   * pass in menu items or buttons as children
-   * @default undefined
-   */
-  children: React$1.ReactNode;
-  /**
-   * an HTML element that's used to set the position of the menu
-   * @default undefined
-   */
-  anchorEl: HTMLElement | null;
-  /**
-   * if true, menu is shown
-   * @default undefined
-   */
-  open: boolean;
+    /**
+     * pass in menu items or buttons as children
+     * @default undefined
+     */
+    children: React$1.ReactNode;
+    /**
+     * an HTML element that's used to set the position of the menu
+     * @default undefined
+     */
+    anchorEl: HTMLElement | null;
+    /**
+     * if true, menu is shown
+     * @default false
+     */
+    open: boolean;
 }
-declare const Menu: ({
-  children,
-  anchorEl,
-  open,
-  ...props
-}: MenuProps) => JSX.Element;
+declare const Menu: ({ children, anchorEl, open, ...props }: MenuProps) => JSX.Element;
 
 interface MenuTopContentProps {
-  onClose?: (args?: any) => void;
-  title?: string;
+    onClose?: (args?: any) => void;
+    title?: string;
 }
-declare const MenuTopContent: ({
-  onClose,
-  title,
-}: MenuTopContentProps) => JSX.Element;
+declare const MenuTopContent: ({ onClose, title }: MenuTopContentProps) => JSX.Element;
 
-export {
-  Banner,
-  BannerProps,
-  Box,
-  BoxProps,
-  Button,
-  ButtonProps,
-  Card,
-  CardColorProperty,
-  CardContent,
-  CardContentProps,
-  CardHeader,
-  CardHeaderProps,
-  CardProps,
-  ConfirmationModal,
-  ConfirmationModalProps,
-  ConfirmationModalVariant,
-  DatePickerField,
-  DatePickerProps,
-  Dialog,
-  DialogActionProps,
-  DialogActions,
-  DialogContentProps,
-  DialogContent as DialogContentText,
-  DialogHeader,
-  DialogHeaderProps,
-  DialogProps,
-  DialogTopContent,
-  DialogTopContentProps,
-  FontWeightValue,
-  FontWeightVariant,
-  IconButton,
-  IconButtonProps,
-  ImageGrid,
-  ImageGridItem,
-  ImageGridItemProps,
-  ImageGridProps,
-  ImageItem,
-  InformationCard,
-  InformationCardProps,
-  InlineNotification,
-  InlineNotificationProps,
-  LineItem,
-  LineItemProps,
-  List,
-  ListItem,
-  ListItemProps,
-  ListProps,
-  Menu,
-  MenuProps,
-  MenuTopContent,
-  MenuTopContentProps,
-  NotificationVariant,
-  StatefulTextField,
-  SuggestedAction,
-  SuggestedActionAccordion,
-  SuggestedActionAccordionProps,
-  SuggestedActionProps,
-  TextField,
-  TextFieldProps,
-  Typography,
-  TypographyProps,
-  fontWeights,
-};
+export { Banner, BannerProps, Box, BoxProps, Button, ButtonProps, Card, CardColorProperty, CardContent, CardContentProps, CardHeader, CardHeaderProps, CardProps, ConfirmationModal, ConfirmationModalProps, ConfirmationModalVariant, DatePickerField, DatePickerProps, Dialog, DialogActionProps, DialogActions, DialogContentProps, DialogContent as DialogContentText, DialogHeader, DialogHeaderProps, DialogProps, DialogTopContent, DialogTopContentProps, FontWeightValue, FontWeightVariant, IconButton, IconButtonProps, ImageGrid, ImageGridItem, ImageGridItemProps, ImageGridProps, ImageItem, InformationCard, InformationCardProps, InlineNotification, InlineNotificationProps, LineItem, LineItemProps, List, ListItem, ListItemProps, ListProps, Menu, MenuProps, MenuTopContent, MenuTopContentProps, NotificationVariant, StatefulTextField, SuggestedAction, SuggestedActionAccordion, SuggestedActionAccordionProps, SuggestedActionProps, TextField, TextFieldProps, Typography, TypographyProps, fontWeights };

--- a/src/components/Dialog/Dialog.stories.mdx
+++ b/src/components/Dialog/Dialog.stories.mdx
@@ -4,7 +4,7 @@ import Dialog from './Dialog';
 import { dialog, argTypes } from './Dialog.stories.tsx';
 
 <Meta
-  title='Molecules/Dialog'
+  title="Molecules/Dialog"
   component={Dialog}
   argTypes={argTypes}
   parameters={{
@@ -18,7 +18,7 @@ A dialog is a basic component to be used across the product.
 It can be composed of `DialogHeader`, `DialogTopContent` and `DialogActions`.
 
 <Canvas>
-  <Story story={dialog} name='Playground' />
+  <Story story={dialog} name="Playground" />
 </Canvas>
 
-<ArgsTable of={Dialog} story='Playground' />
+<ArgsTable of={Dialog} story="Playground" />

--- a/src/components/Dialog/Dialog.stories.mdx
+++ b/src/components/Dialog/Dialog.stories.mdx
@@ -1,14 +1,14 @@
-import { Canvas, Meta, Story, ArgsTable } from "@storybook/addon-docs";
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
 
-import Dialog from "./Dialog";
-import { dialog, argTypes } from "./Dialog.stories.tsx";
+import Dialog from './Dialog';
+import { dialog, argTypes } from './Dialog.stories.tsx';
 
 <Meta
-  title="Molecules/Dialog"
+  title='Molecules/Dialog'
   component={Dialog}
   argTypes={argTypes}
   parameters={{
-    maxWidth: "sm",
+    maxWidth: 'sm',
   }}
 />
 
@@ -18,7 +18,7 @@ A dialog is a basic component to be used across the product.
 It can be composed of `DialogHeader`, `DialogTopContent` and `DialogActions`.
 
 <Canvas>
-  <Story story={dialog} name="Playground" />
+  <Story story={dialog} name='Playground' />
 </Canvas>
 
-<ArgsTable of={Dialog} story="Playground" />
+<ArgsTable of={Dialog} story='Playground' />

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -9,7 +9,9 @@ import { menu, argTypes } from './Menu.stories.tsx';
 
 A `Menu` displays a list of choices on a temporary surfaces, or popovers. It appears when a user interacts with a button or some other control.
 `Menus` are meant to be less disruptive to a user's current context compared to `Dialogs`.
-It can be composed of `MenuTopContent` and any number of `MenuItems` or any number of `Buttons`.
+
+A `Menu` can be composed of `MenuTopContent` and any number of `MenuItems` or any number of `Buttons`. Choosing an option like clicking a button
+should immediately commit the the option and close the menu.
 
 <Canvas>
   <Story story={menu} name='Playground' />

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -7,7 +7,7 @@ import { menu, argTypes } from './Menu.stories.tsx';
 
 # Menu
 
-A `Menu` displays a list of items on a popover when a user interacts with a button or some other control.
+A `Menu` displays a list of choices on a temporary surfaces, or popovers. It appears when a user interacts with a button or some other control.
 `Menus` are meant to be less disruptive to a user's current context compared to `Dialogs`.
 It can be composed of `MenuTopContent` and any number of `MenuItems` or any number of `Buttons`.
 

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -1,7 +1,12 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 
 import Menu from './Menu';
+import MenuTopContent from '../MenuTopContent';
 import { menu, argTypes } from './Menu.stories.tsx';
+
+export const MenuTopContentTemplate = (args) => {
+  return <MenuTopContent {...args} />;
+};
 
 <Meta title='Molecules/Menu' component={Menu} argTypes={argTypes} />
 
@@ -12,6 +17,14 @@ A `Menu` displays a list of choices on a temporary surfaces, or popovers. It app
 
 A `Menu` can be composed of `MenuTopContent` and any number of `MenuItems` or any number of `Buttons`. Choosing an option like clicking a button
 should immediately commit the the option and close the menu.
+
+The most notable props that `Menu` accepts are `anchorEl` which sets the position of the menu to the referenced anchor. The `open` prop determines if
+the menu is open or not. `MenuItems`, `MenuTopContent`, and `Buttons` are passed as children.
+
+# MenuTopContent
+
+`MenuTopContent` is a custom component that displays a title for the menu. It takes an optional `title` prop and an optional `onClose` prop.
+If `onClose` is defined, `MenuTopContent` will display an `X` (close) icon.
 
 <Canvas>
   <Story story={menu} name='Playground' />

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -1,0 +1,18 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
+
+import Menu from './Menu';
+import { menu, argTypes } from './Menu.stories.tsx';
+
+<Meta title='Molecules/Menu' component={Menu} argTypes={argTypes} />
+
+# Menu
+
+A `Menu` displays a list of items on a popover when a user interacts with a button or some other control.
+`Menus` are meant to be less disruptive to a user's current context compared to `Dialogs`.
+It can be composed of `MenuTopContent` and any number of `MenuItems` or any number of `Buttons`.
+
+<Canvas>
+  <Story story={menu} name='Playground' />
+</Canvas>
+
+<ArgsTable of={Menu} story='Playground' />

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -12,8 +12,8 @@ export const MenuTopContentTemplate = (args) => {
 
 # Menu
 
-A `Menu` displays a list of choices on a temporary surfaces, or popovers. It appears when a user interacts with a button or some other control.
-`Menus` are meant to be less disruptive to a user's current context compared to `Dialogs`.
+A `Menu` displays a list of choices on a temporary surfaces or popovers. It appears when a user interacts with a button or some other control.
+`Menu`s are meant to be less disruptive to a user's current context compared to `Dialog`s.
 
 A `Menu` can be composed of `MenuTopContent` and any number of `MenuItems` or any number of `Buttons`. Choosing an option like clicking a button
 should immediately commit the the option and close the menu.
@@ -27,7 +27,7 @@ the menu is open or not. `MenuItems`, `MenuTopContent`, and `Buttons` are passed
 If `onClose` is defined, `MenuTopContent` will display an `X` (close) icon.
 
 <Canvas>
-  <Story story={menu} name='Playground' />
+  <Story story={menu} name='Sandbox' />
 </Canvas>
 
-<ArgsTable of={Menu} story='Playground' />
+<ArgsTable of={Menu} story='Sandbox' />

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useRef } from 'react';
+import { ComponentMeta, Story } from '@storybook/react';
+import { withDesign } from 'storybook-addon-designs';
+import { ArgType } from '@storybook/components';
+
+import Button from '../Button';
+import Menu, { MenuProps } from './Menu';
+import MenuTopContent from '../MenuTopContent/MenuTopContent';
+
+export const argTypes = {
+  children: {
+    defaultValue: <Button />,
+  },
+  anchorEl: {
+    defaultValue: undefined,
+  },
+  open: {
+    defaultValue: false,
+  },
+};
+
+type TemplateArgs = {
+  open: boolean;
+  anchorEl: ArgType;
+  children: ArgType;
+} & MenuProps;
+
+export default {
+  title: 'Molecules/Menu',
+  includeStories: [],
+  decorators: [withDesign],
+  component: Menu,
+  // subcomponents: { ListItem },
+  argTypes: argTypes,
+} as ComponentMeta<typeof Menu>;
+
+const MenuTemplate = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const ref = useRef();
+  const open = Boolean(anchorEl);
+
+  return (
+    <>
+      <Button
+        onClick={() => setAnchorEl(ref.current)}
+        ref={ref}
+        sx={{ margin: 'auto' }}
+      >
+        Open Menu
+      </Button>
+      <Menu
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ horizontal: 'center', vertical: 'top' }}
+      >
+        <MenuTopContent
+          title='More Actions'
+          onClose={() => setAnchorEl(null)}
+        />
+        <Button>Click Me</Button>
+        <Button>Or Me</Button>
+        <Button>Or Me</Button>
+      </Menu>
+    </>
+  );
+};
+
+export const menu: Story<TemplateArgs> = MenuTemplate.bind({});

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -30,7 +30,6 @@ export default {
   includeStories: [],
   decorators: [withDesign],
   component: Menu,
-  // subcomponents: { ListItem },
   argTypes: argTypes,
 } as ComponentMeta<typeof Menu>;
 
@@ -53,15 +52,22 @@ const MenuTemplate = () => {
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        transformOrigin={{ horizontal: 'center', vertical: 'top' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+        sx={{ '& .MuiPaper-root': { width: '390px' } }}
       >
         <MenuTopContent
           title='More Actions'
           onClose={() => setAnchorEl(null)}
         />
-        <Button>Click Me</Button>
-        <Button>Or Me</Button>
-        <Button>Or Me</Button>
+        <Button variant='filled' onClick={() => setAnchorEl(null)}>
+          Click Me
+        </Button>
+        <Button variant='filled' onClick={() => setAnchorEl(null)}>
+          Or Me
+        </Button>
+        <Button variant='filled' onClick={() => setAnchorEl(null)}>
+          Or Me
+        </Button>
       </Menu>
     </>
   );

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -26,17 +26,16 @@ const MenuRoot = styled(MuiMenu)(() => ({
     padding: '16px 24px',
     boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.1)',
     borderRadius: 8,
-    width: '200px',
   },
   '& .MuiMenu-list .MuiButton-root': {
     margin: 'auto',
-    width: '95%',
+    width: '100%',
     marginTop: '10px',
   },
 }));
 
-const Menu = ({ children, anchorEl, open }: MenuProps) => (
-  <MenuRoot anchorEl={anchorEl} open={open}>
+const Menu = ({ children, anchorEl, open, ...props }: MenuProps) => (
+  <MenuRoot anchorEl={anchorEl} open={open} {...props}>
     {children}
   </MenuRoot>
 );

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -13,7 +13,7 @@ export interface MenuProps extends MuiMenuProps {
    * an HTML element that's used to set the position of the menu
    * @default undefined
    */
-  anchorEl: HTMLElement;
+  anchorEl: HTMLElement | null;
   /**
    * if true, menu is shown
    * @default undefined

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Menu as MuiMenu, MenuProps as MuiMenuProps } from '@mui/material';
+
+import styled from '../../theme/styled';
+
+export interface MenuProps extends MuiMenuProps {
+  /**
+   * pass in menu items or buttons as children
+   * @default undefined
+   */
+  children: React.ReactNode;
+  /**
+   * an HTML element that's used to set the position of the menu
+   * @default undefined
+   */
+  anchorEl: HTMLElement;
+  /**
+   * if true, menu is shown
+   * @default undefined
+   */
+  open: boolean;
+}
+
+const MenuRoot = styled(MuiMenu)(() => ({
+  '& .MuiPaper-root': {
+    padding: '16px 24px',
+    boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.1)',
+    borderRadius: 8,
+    width: '200px',
+  },
+  '& .MuiMenu-list .MuiButton-root': {
+    margin: 'auto',
+    width: '95%',
+    marginTop: '10px',
+  },
+}));
+
+const Menu = ({ children, anchorEl, open }: MenuProps) => (
+  <MenuRoot anchorEl={anchorEl} open={open}>
+    {children}
+  </MenuRoot>
+);
+
+export default Menu;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -16,12 +16,12 @@ export interface MenuProps extends MuiMenuProps {
   anchorEl: HTMLElement | null;
   /**
    * if true, menu is shown
-   * @default undefined
+   * @default false
    */
   open: boolean;
 }
 
-const MenuRoot = styled(MuiMenu)(() => ({
+const MenuRoot = styled(MuiMenu, { label: 'Hajimari' })(() => ({
   '& .MuiPaper-root': {
     padding: '16px 24px',
     boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.1)',

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Menu';
+export * from './Menu';

--- a/src/components/MenuTopContent/MenuTopContent.tsx
+++ b/src/components/MenuTopContent/MenuTopContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
 import Box from '../Box';
 import Typography from '../Typography';
 import styled from '../../theme/styled';
+import IconButton from '../IconButton';
 
 export interface MenuTopContentProps {
   onClose?: (args?: any) => void;

--- a/src/components/MenuTopContent/MenuTopContent.tsx
+++ b/src/components/MenuTopContent/MenuTopContent.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { IconButton } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+import Box from '../Box';
+import Typography from '../Typography';
+import styled from '../../theme/styled';
+
+export interface MenuTopContentProps {
+  onClose?: (args?: any) => void;
+  title: string;
+}
+
+const MenuTopContentRoot = styled(Box)(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+}));
+
+const MenuTopContent = ({ onClose, title }: MenuTopContentProps) => (
+  <MenuTopContentRoot>
+    <Typography variant='p1' weight='semibold'>
+      {title}
+    </Typography>
+    <IconButton onClick={onClose} sx={{ ml: 'auto', px: 1 }}>
+      <CloseIcon sx={{ fontSize: 24 }} />
+    </IconButton>
+  </MenuTopContentRoot>
+);
+
+export default MenuTopContent;

--- a/src/components/MenuTopContent/MenuTopContent.tsx
+++ b/src/components/MenuTopContent/MenuTopContent.tsx
@@ -8,7 +8,7 @@ import styled from '../../theme/styled';
 
 export interface MenuTopContentProps {
   onClose?: (args?: any) => void;
-  title: string;
+  title?: string;
 }
 
 const MenuTopContentRoot = styled(Box)(() => ({
@@ -20,12 +20,16 @@ const MenuTopContentRoot = styled(Box)(() => ({
 
 const MenuTopContent = ({ onClose, title }: MenuTopContentProps) => (
   <MenuTopContentRoot>
-    <Typography variant='p1' weight='semibold'>
-      {title}
-    </Typography>
-    <IconButton onClick={onClose} sx={{ ml: 'auto', px: 1 }}>
-      <CloseIcon sx={{ fontSize: 24 }} />
-    </IconButton>
+    {title && (
+      <Typography variant='p1' weight='semibold'>
+        {title}
+      </Typography>
+    )}
+    {onClose && (
+      <IconButton onClick={onClose} sx={{ ml: 'auto', px: 1 }}>
+        <CloseIcon sx={{ fontSize: 24 }} />
+      </IconButton>
+    )}
   </MenuTopContentRoot>
 );
 

--- a/src/components/MenuTopContent/index.ts
+++ b/src/components/MenuTopContent/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MenuTopContent';
+export * from './MenuTopContent';

--- a/src/components/SuggestedAction/SuggestedAction.stories.mdx
+++ b/src/components/SuggestedAction/SuggestedAction.stories.mdx
@@ -7,9 +7,9 @@ import Typography from '../Typography';
 
 export const argTypes = {
   variant: {
-    control: { type: "select" },
-    options: ["green", "yellow", "red", "greyscale"],
-    defaultValue: "green",
+    control: { type: 'select' },
+    options: ['green', 'yellow', 'red', 'greyscale'],
+    defaultValue: 'green',
     type: { required: true },
     table: {
       type: {
@@ -25,9 +25,6 @@ export const argTypes = {
     table: {
       type: { summary: 'ReactNode' },
     },
-  },
-  onClickMenu: {
-    defaultValue: () => null,
   },
   dueDate: {
     defaultValue: 'May 16',
@@ -60,7 +57,7 @@ export const argTypes = {
 };
 
 <Meta
-  title="Molecules/SuggestedAction"
+  title='Molecules/SuggestedAction'
   component={SuggestedAction}
   argTypes={argTypes}
   parameters={{
@@ -93,8 +90,7 @@ which the contractor clicks to take the action suggested.
 
 It has a `variant` attribute, which determines the color of the bar on the left. It has a
 `description` prop, which takes in a `string` or a `ReactNode`. The latter is useful when
-you want to render part of the description in, e.g., semibold font. The `onClickMenu` attribute
-determines what occurs when the user clicks the three dots in the upper right corner. Optionally,
+you want to render part of the description in, e.g., semibold font. Optionally,
 the component takes in a `dueDate`, which displays the date on which the related item is due.
 Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (`ctaAction` and
 `secondaryCtaAction`), with the first CTA being required.
@@ -108,14 +104,13 @@ Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (
 
 <Canvas>
   <Story
-    name="Basic"
+    name='Basic'
     component={SuggestedAction}
     args={{
       variant: 'green',
       description: `Sandy Scientist approved Roofing Quote.`,
       cta: 'Send a Contract',
       ctaAction: () => null,
-      onClickMenu: () => null,
     }}
   >
     {SuggestedActionTemplate.bind()}
@@ -129,19 +124,22 @@ Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (
 
 <Canvas>
   <Story
-    name="Non-string description"
+    name='Non-string description'
     component={SuggestedAction}
     args={{
       variant: 'green',
       description: (
-        <Typography variant="p2">
-          <Box component="span" sx={{ fontWeight: 600  }}>Sandy Scientist </Box>
-          approved <Box component="span" sx={{ fontWeight: 600 }}>Roofing Quote</Box>.
+        <Typography variant='p2'>
+          <Box component='span' sx={{ fontWeight: 600 }}>
+            Sandy Scientist{' '}
+          </Box>
+          approved <Box component='span' sx={{ fontWeight: 600 }}>
+            Roofing Quote
+          </Box>.
         </Typography>
       ),
       cta: 'Send a Contract',
       ctaAction: () => null,
-      onClickMenu: () => null,
     }}
   >
     {SuggestedActionTemplate.bind()}
@@ -154,20 +152,23 @@ Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (
 
 <Canvas>
   <Story
-    name="Due date"
+    name='Due date'
     component={SuggestedAction}
     args={{
       variant: 'yellow',
       description: (
-        <Typography variant="p2">
-          <Box component="span" sx={{ fontWeight: 600  }}>Sandy Scientist's Roofing Quote </Box>
-          is due in <Box component="span" sx={{ fontWeight: 600 }}>3 days</Box>.
+        <Typography variant='p2'>
+          <Box component='span' sx={{ fontWeight: 600 }}>
+            Sandy Scientist's Roofing Quote{' '}
+          </Box>
+          is due in <Box component='span' sx={{ fontWeight: 600 }}>
+            3 days
+          </Box>.
         </Typography>
       ),
       cta: 'Send a Contract',
       dueDate: 'May 16',
       ctaAction: () => null,
-      onClickMenu: () => null,
     }}
   >
     {SuggestedActionTemplate.bind()}
@@ -181,17 +182,18 @@ Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (
 
 <Canvas>
   <Story
-    name="Two CTAs"
+    name='Two CTAs'
     component={SuggestedAction}
     args={{
       variant: 'red',
       description: (
-        <Typography variant="p2">
-          <Box component="span" sx={{ fontWeight: 600  }}>Sandy Scientist's Roofing Quote </Box>
+        <Typography variant='p2'>
+          <Box component='span' sx={{ fontWeight: 600 }}>
+            Sandy Scientist's Roofing Quote{' '}
+          </Box>
           is overdue.
         </Typography>
       ),
-      onClickMenu: () => null,
       cta: 'Send reminder',
       ctaAction: () => null,
       secondaryCta: 'Cancel quote',
@@ -209,7 +211,7 @@ Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (
 ### Playground
 
 <Canvas>
-  <Story name="Playground">{SuggestedActionTemplate.bind()}</Story>
+  <Story name='Playground'>{SuggestedActionTemplate.bind()}</Story>
 </Canvas>
 
-<ArgsTable of={SuggestedAction} story="Playground" />
+<ArgsTable of={SuggestedAction} story='Playground' />

--- a/src/components/SuggestedAction/SuggestedAction.stories.mdx
+++ b/src/components/SuggestedAction/SuggestedAction.stories.mdx
@@ -93,7 +93,8 @@ It has a `variant` attribute, which determines the color of the bar on the left.
 you want to render part of the description in, e.g., semibold font. Optionally,
 the component takes in a `dueDate`, which displays the date on which the related item is due.
 Finally, it takes in up to two CTAs (`cta` and `secondaryCta`) and CTA actions (`ctaAction` and
-`secondaryCtaAction`), with the first CTA being required.
+`secondaryCtaAction`), with the first CTA being required. Clicking the 3 dots renders a `SuggestedActionHamburgerMenu`
+which gives the user access to more actions.
 
 <br />
 

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
+import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 
 import Box from '../Box';
 import Typography from '../Typography';
 import Button from '../Button';
 import IconButton from '../IconButton';
+import SuggestedActionHamburgerMenu from '../SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu';
+import MenuTopContent from '../MenuTopContent';
 
 type SuggestedActionVariant = 'green' | 'yellow' | 'red' | 'greyscale';
 
@@ -43,6 +48,7 @@ const SuggestedAction = ({
   hideCtas,
   children,
 }: SuggestedActionProps): JSX.Element => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const setBorderColor = (variant: SuggestedActionVariant): HajimariColor => {
     switch (variant) {
       case 'green':
@@ -57,85 +63,108 @@ const SuggestedAction = ({
   };
 
   return (
-    <Box
-      sx={{
-        padding: '8px 0 12px 0',
-        bgcolor: 'greyscale.100',
-        display: 'flex',
-      }}
-    >
+    <>
+      <SuggestedActionHamburgerMenu
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+      >
+        <MenuTopContent
+          title='More Actions'
+          onClose={() => setAnchorEl(null)}
+        />
+        <Button variant='filled' startIcon={<OpenInBrowserIcon />}>
+          View Details
+        </Button>
+        <Button variant='filled' startIcon={<HighlightOffIcon />}>
+          Dismiss
+        </Button>
+        <Button variant='filled' startIcon={<NotificationsOffIcon />}>
+          Don't Show This Again
+        </Button>
+      </SuggestedActionHamburgerMenu>
       <Box
         sx={{
-          borderRadius: 2,
-          backgroundColor: setBorderColor(variant),
-          py: 0.5,
-          ml: 0.375,
-          width: 4,
-        }}
-      />
-      <Box
-        sx={{
+          padding: '8px 0 12px 0',
+          bgcolor: 'greyscale.100',
           display: 'flex',
-          flexDirection: 'column',
-          pl: 1.875,
-          width: '100%',
         }}
       >
         <Box
           sx={{
+            borderRadius: 2,
+            backgroundColor: setBorderColor(variant),
+            py: 0.5,
+            ml: 0.375,
+            width: 4,
+          }}
+        />
+        <Box
+          sx={{
             display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
+            flexDirection: 'column',
+            pl: 1.875,
+            width: '100%',
           }}
         >
-          {typeof description === 'string' ? (
-            <Typography variant="p2">{description}</Typography>
-          ) : (
-            description
-          )}
-          <Box sx={{ mr: 3 }} />
-          <IconButton
-            onClick={onClickMenu}
-            sx={{
-              py: 0,
-              px: 0.5,
-            }}
-          >
-            <MoreVertIcon />
-          </IconButton>
-        </Box>
-        {dueDate && (
-          <Typography variant="p3" sx={{ mt: 1 }}>
-            Due on {dueDate}
-          </Typography>
-        )}
-        {!hideCtas && (
           <Box
             sx={{
-              mt: 1.5,
               display: 'flex',
-              width: 'fit-content',
-              flexWrap: { xs: 'wrap', sm: 'unset' },
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
             }}
           >
-            <Button variant="text" onClick={ctaAction} align="left">
-              {cta}
-            </Button>
-            {secondaryCta && secondaryCtaAction && (
-              <Button
-                variant="text"
-                onClick={secondaryCtaAction}
-                sx={{ ml: { xs: -2, sm: 0.5 } }}
-                align="left"
-              >
-                {secondaryCta}
-              </Button>
+            {typeof description === 'string' ? (
+              <Typography variant='p2'>{description}</Typography>
+            ) : (
+              description
             )}
+            <Box sx={{ mr: 3 }} />
+            <IconButton
+              onClick={(e) => {
+                setAnchorEl(e.currentTarget);
+              }}
+              sx={{
+                py: 0,
+                px: 0.5,
+              }}
+            >
+              <MoreVertIcon />
+            </IconButton>
           </Box>
-        )}
-        {children}
+          {dueDate && (
+            <Typography variant='p3' sx={{ mt: 1 }}>
+              Due on {dueDate}
+            </Typography>
+          )}
+          {!hideCtas && (
+            <Box
+              sx={{
+                mt: 1.5,
+                display: 'flex',
+                width: 'fit-content',
+                flexWrap: { xs: 'wrap', sm: 'unset' },
+              }}
+            >
+              <Button variant='text' onClick={ctaAction} align='left'>
+                {cta}
+              </Button>
+              {secondaryCta && secondaryCtaAction && (
+                <Button
+                  variant='text'
+                  onClick={secondaryCtaAction}
+                  sx={{ ml: { xs: -2, sm: 0.5 } }}
+                  align='left'
+                >
+                  {secondaryCta}
+                </Button>
+              )}
+            </Box>
+          )}
+          {children}
+        </Box>
       </Box>
-    </Box>
+    </>
   );
 };
 

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -32,16 +32,14 @@ export interface SuggestedActionProps {
   hideCtas?: boolean;
   /* any children components; optional */
   children?: React.ReactNode;
-  hamburgerActionProps: {
-    workflow: string;
-    /* these next three props are actions for the hamburger menu, all the arguments are specified in izakaya */
-    /* dismisses the suggestedaction */
-    dismissAction: () => void;
-    /* lets the contractor view the workflow details */
-    viewWorkflow: () => void;
-    /* disables all suggested actions of the specified type */
-    disableAction: () => void;
-  };
+  workflow: string;
+  /* these next three props are actions for the hamburger menu, all the arguments are specified in izakaya */
+  /* dismisses the suggestedaction */
+  dismissAction: () => void;
+  /* lets the contractor view the workflow details */
+  viewWorkflow: () => void;
+  /* disables all suggested actions of the specified type */
+  disableAction: () => void;
 }
 
 const SuggestedAction = ({
@@ -54,7 +52,10 @@ const SuggestedAction = ({
   secondaryCtaAction,
   hideCtas,
   children,
-  hamburgerActionProps,
+  workflow,
+  viewWorkflow,
+  disableAction,
+  dismissAction,
 }: SuggestedActionProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const setBorderColor = (variant: SuggestedActionVariant): HajimariColor => {
@@ -69,9 +70,6 @@ const SuggestedAction = ({
         return 'greyscale.700';
     }
   };
-
-  const { viewWorkflow, disableAction, dismissAction, workflow } =
-    hamburgerActionProps;
 
   return (
     <>

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -93,14 +93,20 @@ const SuggestedAction = ({
         <Button
           variant='filled'
           startIcon={<HighlightOffIcon />}
-          onClick={dismissAction}
+          onClick={() => {
+            dismissAction();
+            setAnchorEl(null);
+          }}
         >
           Dismiss
         </Button>
         <Button
           variant='filled'
           startIcon={<NotificationsOffIcon />}
-          onClick={disableAction}
+          onClick={() => {
+            disableAction();
+            setAnchorEl(null);
+          }}
         >
           Don't Show This Again
         </Button>

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -18,8 +18,6 @@ export interface SuggestedActionProps {
   variant: SuggestedActionVariant;
   /* copy -- react node to allow control over bold text */
   description: React.ReactNode;
-  /* what happens when the menu icon is clicked */
-  onClickMenu: () => void;
   /* due date */
   dueDate?: string;
   /* left cta copy */
@@ -36,10 +34,19 @@ export interface SuggestedActionProps {
   children?: React.ReactNode;
 }
 
+/**
+ *
+ * 1. View workflow details
+ *  /dashboard/clients/${homeownerId}/quote/${quoteId}
+ * 2. Dismiss
+ *  suggestedActionId
+ * 3. Don't show this again
+ * suggestedActionTypeID
+ */
+
 const SuggestedAction = ({
   variant,
   description,
-  onClickMenu,
   dueDate,
   cta,
   ctaAction,

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -83,7 +83,10 @@ const SuggestedAction = ({
         <Button
           variant='filled'
           startIcon={<OpenInBrowserIcon />}
-          onClick={viewWorkflow}
+          onClick={() => {
+            viewWorkflow();
+            setAnchorEl(null);
+          }}
         >
           View Details
         </Button>

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -32,17 +32,14 @@ export interface SuggestedActionProps {
   hideCtas?: boolean;
   /* any children components; optional */
   children?: React.ReactNode;
+  /* these next three props are actions for the hamburger menu, all the arguments are specified in izakaya */
+  /* dismisses the suggestedaction */
+  dismissAction: () => void;
+  /* lets the contractor view the workflow details */
+  viewWorkflow: () => void;
+  /* disables all suggested actions of the specified type */
+  disableAction: () => void;
 }
-
-/**
- *
- * 1. View workflow details
- *  /dashboard/clients/${homeownerId}/quote/${quoteId}
- * 2. Dismiss
- *  suggestedActionId
- * 3. Don't show this again
- * suggestedActionTypeID
- */
 
 const SuggestedAction = ({
   variant,
@@ -54,6 +51,9 @@ const SuggestedAction = ({
   secondaryCtaAction,
   hideCtas,
   children,
+  dismissAction,
+  viewWorkflow,
+  disableAction,
 }: SuggestedActionProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const setBorderColor = (variant: SuggestedActionVariant): HajimariColor => {
@@ -80,13 +80,25 @@ const SuggestedAction = ({
           title='More Actions'
           onClose={() => setAnchorEl(null)}
         />
-        <Button variant='filled' startIcon={<OpenInBrowserIcon />}>
+        <Button
+          variant='filled'
+          startIcon={<OpenInBrowserIcon />}
+          onClick={viewWorkflow}
+        >
           View Details
         </Button>
-        <Button variant='filled' startIcon={<HighlightOffIcon />}>
+        <Button
+          variant='filled'
+          startIcon={<HighlightOffIcon />}
+          onClick={dismissAction}
+        >
           Dismiss
         </Button>
-        <Button variant='filled' startIcon={<NotificationsOffIcon />}>
+        <Button
+          variant='filled'
+          startIcon={<NotificationsOffIcon />}
+          onClick={disableAction}
+        >
           Don't Show This Again
         </Button>
       </SuggestedActionHamburgerMenu>

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
@@ -32,13 +32,16 @@ export interface SuggestedActionProps {
   hideCtas?: boolean;
   /* any children components; optional */
   children?: React.ReactNode;
-  /* these next three props are actions for the hamburger menu, all the arguments are specified in izakaya */
-  /* dismisses the suggestedaction */
-  dismissAction: () => void;
-  /* lets the contractor view the workflow details */
-  viewWorkflow: () => void;
-  /* disables all suggested actions of the specified type */
-  disableAction: () => void;
+  hamburgerActionProps: {
+    workflow: string;
+    /* these next three props are actions for the hamburger menu, all the arguments are specified in izakaya */
+    /* dismisses the suggestedaction */
+    dismissAction: () => void;
+    /* lets the contractor view the workflow details */
+    viewWorkflow: () => void;
+    /* disables all suggested actions of the specified type */
+    disableAction: () => void;
+  };
 }
 
 const SuggestedAction = ({
@@ -51,9 +54,7 @@ const SuggestedAction = ({
   secondaryCtaAction,
   hideCtas,
   children,
-  dismissAction,
-  viewWorkflow,
-  disableAction,
+  hamburgerActionProps,
 }: SuggestedActionProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const setBorderColor = (variant: SuggestedActionVariant): HajimariColor => {
@@ -68,6 +69,9 @@ const SuggestedAction = ({
         return 'greyscale.700';
     }
   };
+
+  const { viewWorkflow, disableAction, dismissAction, workflow } =
+    hamburgerActionProps;
 
   return (
     <>
@@ -88,7 +92,7 @@ const SuggestedAction = ({
             setAnchorEl(null);
           }}
         >
-          View Details
+          View {workflow} Details
         </Button>
         <Button
           variant='filled'

--- a/src/components/SuggestedActionAccordion/SuggestedActionAccordion.stories.mdx
+++ b/src/components/SuggestedActionAccordion/SuggestedActionAccordion.stories.mdx
@@ -8,9 +8,9 @@ import Box from '../Box';
 
 export const argTypes = {
   variant: {
-    control: { type: "select" },
-    options: ["green", "yellow", "red", "greyscale"],
-    defaultValue: "green",
+    control: { type: 'select' },
+    options: ['green', 'yellow', 'red', 'greyscale'],
+    defaultValue: 'green',
     type: { required: true },
     table: {
       type: {
@@ -40,15 +40,16 @@ export const argTypes = {
     },
   },
   children: {
-    defaultValue: new Array(3).fill(null).map(_ =>
-      <SuggestedAction
-        variant="green"
-        description="Harry Homeowner has signed Roofing Contract"
-        onClickMenu={() => {}}
-        cta="Send an invoice"
-        ctaAction={() => {}}
-      />
-    ),
+    defaultValue: new Array(3)
+      .fill(null)
+      .map((_) => (
+        <SuggestedAction
+          variant='green'
+          description='Harry Homeowner has signed Roofing Contract'
+          cta='Send an invoice'
+          ctaAction={() => {}}
+        />
+      )),
     table: {
       type: { summary: 'ReactNode' },
     },
@@ -63,7 +64,7 @@ export const argTypes = {
 };
 
 <Meta
-  title="Molecules/SuggestedActionAccordion"
+  title='Molecules/SuggestedActionAccordion'
   component={SuggestedActionAccordion}
   argTypes={argTypes}
   parameters={{
@@ -75,7 +76,9 @@ export const argTypes = {
   }}
 />
 
-export const SuggestedActionAccordionTemplate = (args) => <SuggestedActionAccordion {...args} />;
+export const SuggestedActionAccordionTemplate = (args) => (
+  <SuggestedActionAccordion {...args} />
+);
 
 # SuggestedActionAccordion
 
@@ -109,21 +112,22 @@ attribute, which determines whether the component renders in a disabled state.
 
 <Canvas>
   <Story
-    name="Basic"
+    name='Basic'
     component={SuggestedActionAccordion}
     args={{
       variant: 'green',
       groupTitle: 'Ready for action',
       numItems: 3,
-      children: new Array(3).fill(null).map(_ =>
-        <SuggestedAction
-          variant="green"
-          description="Harry Homeowner has signed Roofing Contract"
-          onClickMenu={() => {}}
-          cta="Send an invoice"
-          ctaAction={() => {}}
-        />
-      ),
+      children: new Array(3)
+        .fill(null)
+        .map((_) => (
+          <SuggestedAction
+            variant='green'
+            description='Harry Homeowner has signed Roofing Contract'
+            cta='Send an invoice'
+            ctaAction={() => {}}
+          />
+        )),
     }}
   >
     {SuggestedActionAccordionTemplate.bind()}
@@ -137,21 +141,22 @@ attribute, which determines whether the component renders in a disabled state.
 
 <Canvas>
   <Story
-    name="Controlled"
+    name='Controlled'
     component={SuggestedActionAccordion}
     args={{
       variant: 'green',
       groupTitle: 'Ready for action',
       numItems: 3,
-      children: new Array(3).fill(null).map(_ =>
-        <SuggestedAction
-          variant="green"
-          description="Harry Homeowner has signed Roofing Contract"
-          onClickMenu={() => {}}
-          cta="Send an invoice"
-          ctaAction={() => {}}
-        />
-      ),
+      children: new Array(3)
+        .fill(null)
+        .map((_) => (
+          <SuggestedAction
+            variant='green'
+            description='Harry Homeowner has signed Roofing Contract'
+            cta='Send an invoice'
+            ctaAction={() => {}}
+          />
+        )),
       expanded: true,
     }}
   >
@@ -166,7 +171,7 @@ attribute, which determines whether the component renders in a disabled state.
 
 <Canvas>
   <Story
-    name="Disabled"
+    name='Disabled'
     component={SuggestedActionAccordion}
     args={{
       variant: 'green',
@@ -188,21 +193,22 @@ attribute, which determines whether the component renders in a disabled state.
 
 <Canvas>
   <Story
-    name="Highlight Number"
+    name='Highlight Number'
     component={SuggestedActionAccordion}
     args={{
       variant: 'green',
       groupTitle: 'Ready for action',
       numItems: 3,
-      children: new Array(3).fill(null).map(_ =>
-        <SuggestedAction
-          variant="green"
-          description="Harry Homeowner has signed Roofing Contract"
-          onClickMenu={() => {}}
-          cta="Send an invoice"
-          ctaAction={() => {}}
-        />
-      ),
+      children: new Array(3)
+        .fill(null)
+        .map((_) => (
+          <SuggestedAction
+            variant='green'
+            description='Harry Homeowner has signed Roofing Contract'
+            cta='Send an invoice'
+            ctaAction={() => {}}
+          />
+        )),
       highlightNumber: true,
     }}
   >
@@ -213,7 +219,7 @@ attribute, which determines whether the component renders in a disabled state.
 ### Playground
 
 <Canvas>
-  <Story name="Playground">{SuggestedActionAccordionTemplate.bind()}</Story>
+  <Story name='Playground'>{SuggestedActionAccordionTemplate.bind()}</Story>
 </Canvas>
 
-<ArgsTable of={SuggestedActionAccordion} story="Playground" />
+<ArgsTable of={SuggestedActionAccordion} story='Playground' />

--- a/src/components/SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu.tsx
+++ b/src/components/SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu.tsx
@@ -8,16 +8,6 @@ export interface SuggestedActionHamburgerMenuProps extends MenuProps {
   onClose: (args?: any) => void;
 }
 
-/**
- *
- * 1. View workflow details
- *  /dashboard/clients/${homeownerId}/quote/${quoteId}
- * 2. Dismiss
- *  suggestedActionId
- * 3. Don't show this again
- * suggestedActionTypeID
- */
-
 const SuggestedActionHamburgerMenu = ({
   open,
   anchorEl,
@@ -31,7 +21,7 @@ const SuggestedActionHamburgerMenu = ({
     onClose={onClose}
     anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
     transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-    sx={{ '& .MuiPaper-root': { width: '30%', minWidth: '270px' } }}
+    sx={{ '& .MuiPaper-root': { width: '25%', minWidth: '270px' } }}
     {...props}
   >
     {children}

--- a/src/components/SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu.tsx
+++ b/src/components/SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import Menu, { MenuProps } from '../Menu';
+
+export interface SuggestedActionHamburgerMenuProps extends MenuProps {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: (args?: any) => void;
+}
+
+/**
+ *
+ * 1. View workflow details
+ *  /dashboard/clients/${homeownerId}/quote/${quoteId}
+ * 2. Dismiss
+ *  suggestedActionId
+ * 3. Don't show this again
+ * suggestedActionTypeID
+ */
+
+const SuggestedActionHamburgerMenu = ({
+  open,
+  anchorEl,
+  onClose,
+  children,
+  ...props
+}: SuggestedActionHamburgerMenuProps) => (
+  <Menu
+    open={open}
+    anchorEl={anchorEl}
+    onClose={onClose}
+    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+    sx={{ '& .MuiPaper-root': { width: '30%', minWidth: '270px' } }}
+    {...props}
+  >
+    {children}
+  </Menu>
+);
+
+export default SuggestedActionHamburgerMenu;

--- a/src/components/SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu.tsx
+++ b/src/components/SuggestedActionHamburgerMenu/SuggestedActionHamburgerMenu.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import Menu, { MenuProps } from '../Menu';
-
+import styled from '../../theme/styled';
 export interface SuggestedActionHamburgerMenuProps extends MenuProps {
   open: boolean;
   anchorEl: HTMLElement | null;
   onClose: (args?: any) => void;
 }
+
+const MenuRoot = styled(Menu)(() => ({
+  '& .MuiPaper-root': { width: '25%', minWidth: '270px' },
+}));
 
 const SuggestedActionHamburgerMenu = ({
   open,
@@ -15,17 +19,16 @@ const SuggestedActionHamburgerMenu = ({
   children,
   ...props
 }: SuggestedActionHamburgerMenuProps) => (
-  <Menu
+  <MenuRoot
     open={open}
     anchorEl={anchorEl}
     onClose={onClose}
     anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
     transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-    sx={{ '& .MuiPaper-root': { width: '25%', minWidth: '270px' } }}
     {...props}
   >
     {children}
-  </Menu>
+  </MenuRoot>
 );
 
 export default SuggestedActionHamburgerMenu;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -75,3 +75,9 @@ export * from './Field/TextField/TextField';
 
 export { default as Typography } from './Typography';
 export * from './Typography/Typography';
+
+export { default as Menu } from './Menu';
+export * from './Menu';
+
+export { default as MenuTopContent } from './MenuTopContent';
+export * from './MenuTopContent';


### PR DESCRIPTION
Pretty minimal `Menu` Component with an addition of `MenuTopContent`. More substantially, suggested action's `HamburgerMenu` is being rendered here. It makes the anchoring of the menu **a lot** easier than doing it in izakaya. As such, `SuggestedActions` component has to take in a couple new props to render the hamburger menu actions.

![Screen Shot 2022-08-02 at 5 09 28 PM](https://user-images.githubusercontent.com/73679611/182497325-8b7b15e7-d51b-43b9-aed0-eed408a92aad.png)
![Screen Shot 2022-08-02 at 5 09 04 PM](https://user-images.githubusercontent.com/73679611/182497288-4cfe4303-dd32-4af0-b4c0-e379bfb6a71e.png)

