### PR TITLE
SA Menu - make viewWorkflow optional

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -360,7 +360,7 @@ interface SuggestedActionProps {
     children?: React$1.ReactNode;
     workflow: string;
     dismissAction: () => void;
-    viewWorkflow: () => void;
+    viewWorkflow?: () => void;
     disableAction: () => void;
 }
 declare const SuggestedAction: ({ variant, description, dueDate, cta, ctaAction, secondaryCta, secondaryCtaAction, hideCtas, children, workflow, viewWorkflow, disableAction, dismissAction, }: SuggestedActionProps) => JSX.Element;

--- a/src/components/SuggestedAction/SuggestedAction.stories.mdx
+++ b/src/components/SuggestedAction/SuggestedAction.stories.mdx
@@ -205,6 +205,38 @@ which gives the user access to more actions.
   </Story>
 </Canvas>
 
+#### Hamburger Menu:
+
+> Every suggested action has a `hamburger menu` that's accessible by clicking the three dots on the top right corner.
+> The `SuggestedActionHamburgerMenu` is built on the `Menu` component with a `More Actions` title. Most hamburger menus will
+> contain three ctas: `View {Workflow} Details`, `Dismiss`, and `Don't show this again`. Some will only have the latter two.
+> We can determine whether or not to render the `View {Workflow} Details` by checking that the `viewWorkflow` prop is defined.
+
+<Canvas>
+  <Story
+    name='Hamburger Menu'
+    component={SuggestedAction}
+    args={{
+      variant: 'red',
+      description: (
+        <Typography variant='p2'>
+          <Box component='span' sx={{ fontWeight: 600 }}>
+            Sandy Scientist's Roofing Quote{' '}
+          </Box>
+          is overdue.
+        </Typography>
+      ),
+      cta: 'Send reminder',
+      ctaAction: () => null,
+      secondaryCta: 'Cancel quote',
+      secondaryCtaAction: () => null,
+      viewWorkflow: () => null,
+    }}
+  >
+    {SuggestedActionTemplate.bind()}
+  </Story>
+</Canvas>
+
 ---
 
 <br />

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -37,7 +37,7 @@ export interface SuggestedActionProps {
   /* dismisses the suggestedaction */
   dismissAction: () => void;
   /* lets the contractor view the workflow details */
-  viewWorkflow: () => void;
+  viewWorkflow?: () => void;
   /* disables all suggested actions of the specified type */
   disableAction: () => void;
 }
@@ -82,16 +82,18 @@ const SuggestedAction = ({
           title='More Actions'
           onClose={() => setAnchorEl(null)}
         />
-        <Button
-          variant='filled'
-          startIcon={<OpenInBrowserIcon />}
-          onClick={() => {
-            viewWorkflow();
-            setAnchorEl(null);
-          }}
-        >
-          View {workflow} Details
-        </Button>
+        {viewWorkflow && (
+          <Button
+            variant='filled'
+            startIcon={<OpenInBrowserIcon />}
+            onClick={() => {
+              viewWorkflow();
+              setAnchorEl(null);
+            }}
+          >
+            View {workflow} Details
+          </Button>
+        )}
         <Button
           variant='filled'
           startIcon={<HighlightOffIcon />}

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -32,7 +32,7 @@ export interface SuggestedActionProps {
   hideCtas?: boolean;
   /* any children components; optional */
   children?: React.ReactNode;
-  workflow: string;
+  workflow?: string;
   /* these next three props are actions for the hamburger menu, all the arguments are specified in izakaya */
   /* dismisses the suggestedaction */
   dismissAction: () => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   SuggestedActionAccordion,
   SuggestedActionProps,
   ConfirmationModal,
+  TextField,
 } from './components';
 import {
   darken,
@@ -91,4 +92,5 @@ export {
   SuggestedActionProps,
   SuggestedActionAccordion,
   ConfirmationModal,
+  TextField,
 };


### PR DESCRIPTION
Jono pointed out that there are suggested actions that don't need the `view details` cta. This PR makes it optional + adds some explanations to the markdown page for more clarity. 

also has textfield export