### PR TITLE
[ROK-1085] SA + text button updates

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -108,8 +108,14 @@ const ButtonRoot = styled(MuiButton, {
     }),
   },
   ...(variant === 'text' && {
-    ...(align === 'left' && { marginLeft: -16 }),
-    ...(align === 'right' && { marginRight: -16 }),
+    paddingLeft: 12,
+    paddingRight: 12,
+    ...(align === 'left' && {
+      marginLeft: -12,
+    }),
+    ...(align === 'right' && {
+      marginRight: -12,
+    }),
   }),
 }));
 

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -120,13 +120,14 @@ const SuggestedAction = ({
           padding: '8px 0 12px 0',
           bgcolor: 'greyscale.100',
           display: 'flex',
+          position: 'relative',
         }}
       >
         <Box
           sx={{
             borderRadius: 2,
             backgroundColor: setBorderColor(variant),
-            py: 0.5,
+            mb: 1.5,
             ml: 0.375,
             width: 4,
           }}
@@ -156,10 +157,7 @@ const SuggestedAction = ({
               onClick={(e) => {
                 setAnchorEl(e.currentTarget);
               }}
-              sx={{
-                py: 0,
-                px: 0.5,
-              }}
+              sx={{ position: 'absolute', top: 0, right: 0 }}
             >
               <MoreVertIcon />
             </IconButton>
@@ -172,21 +170,30 @@ const SuggestedAction = ({
           {!hideCtas && (
             <Box
               sx={{
-                mt: 1.5,
+                mt: 1,
                 display: 'flex',
                 width: 'fit-content',
-                flexWrap: { xs: 'wrap', sm: 'unset' },
+                flexDirection: { xs: 'column', sm: 'row' },
+                alignItems: { xs: 'flex-start', sm: 'unset' }
               }}
             >
-              <Button variant='text' onClick={ctaAction} align='left'>
+              <Button
+                variant='text'
+                onClick={ctaAction}
+                align='left'
+              >
                 {cta}
               </Button>
               {secondaryCta && secondaryCtaAction && (
                 <Button
                   variant='text'
                   onClick={secondaryCtaAction}
-                  sx={{ ml: { xs: -2, sm: 0.5 } }}
                   align='left'
+                  sx={{
+                    ml: { sm: 0.5 },
+                    // a Button, in general, has a default minWidth of 148px
+                    minWidth: { xs: 0, sm: 148 },
+                  }}
                 >
                   {secondaryCta}
                 </Button>


### PR DESCRIPTION
### Description:
on `Button`:
- for the `Text` variant, reduce padding to `12px` so that on hover, it doesn't clash into the edges of its parent container
- adjust styles slightly for this

on `SuggestedAction`:
- remove the `sx` from the three dots `IconButton` so the hover state is correct; added absolute positioning
- render the action buttons slightly differently so that they look fine on web + stack correctly on mobile

![Screen Shot 2022-08-08 at 8 49 10 PM](https://user-images.githubusercontent.com/9397381/183776975-04ade1a6-1b60-401f-aecc-1345fdfd24d3.png)
![Screen Shot 2022-08-08 at 8 48 13 PM](https://user-images.githubusercontent.com/9397381/183777021-5caea2e9-81ac-45f9-a880-370de9613d7b.png)

### Jira:
https://gethearth.atlassian.net/browse/ROK-1085