### PR TITLE
TextField - make mask optional

### DIFF
--- a/src/components/Field/TextField/TextField.tsx
+++ b/src/components/Field/TextField/TextField.tsx
@@ -4,7 +4,7 @@ import MuiTextField, { TextFieldProps as MuiTextFieldProps } from '@mui/material
 import { Mask, maskTypes } from './utils';
 
 export type TextFieldProps = {
-  mask: Mask;
+  mask?: Mask;
   value?: string;
 } & MuiTextFieldProps;
 


### PR DESCRIPTION
@NelsonLee-Code encountered several TS errors related to the `mask` prop while committing on izakaya. We traced this to hajimari's `TextField` component, which requires an argument for `mask` despite specifying a default value. This PR makes the `mask` prop optional.