### PR TITLE
Adjust SA buttons

### DIFF
--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -190,7 +190,7 @@ const SuggestedAction = ({
                 align="left"
                 sx={{
                   // a Button, in general, has a default minWidth of 148px
-                  minWidth: { xs: 0, sm: 148 },
+                  minWidth: 0,
                 }}
               >
                 {cta}
@@ -203,7 +203,7 @@ const SuggestedAction = ({
                   sx={{
                     ml: { sm: 0.5 },
                     // a Button, in general, has a default minWidth of 148px
-                    minWidth: { xs: 0, sm: 148 },
+                    minWidth: 0,
                   }}
                 >
                   {secondaryCta}

--- a/src/components/SuggestedAction/SuggestedAction.tsx
+++ b/src/components/SuggestedAction/SuggestedAction.tsx
@@ -164,7 +164,7 @@ const SuggestedAction = ({
                 setAnchorEl(e.currentTarget);
                 viewMenuCallback();
               }}
-              sx={{ position: 'absolute', top: 0, right: 0 }}
+              sx={{ position: 'absolute', top: 0, right: 0, px: '3px' }}
             >
               <MoreVertIcon />
             </IconButton>


### PR DESCRIPTION
- This _does_ resolve the text in CTA buttons not aligning perfectly with the description text
- Also fixes the alignment of icon button to be the same width of the expand icon (24px)
- Side effect is that theoretically a button could be zero width, but I think we'd have a different issue in that case 🤔 

Small:
![Screen Shot 2022-08-22 at 12 06 09 AM](https://user-images.githubusercontent.com/1946255/185837525-ed12c02d-b463-4b95-83f1-f7670744d643.png)

Large:
![Screen Shot 2022-08-22 at 12 06 01 AM](https://user-images.githubusercontent.com/1946255/185837541-65da3d70-3ab9-4788-ae80-aad198e1f588.png)

Icon Button:
![Screen Shot 2022-08-22 at 12 04 58 AM](https://user-images.githubusercontent.com/1946255/185837382-7b0f0aba-4dd5-4450-b604-186c25145a36.png)


