### PR TITLE
GZA-627-disable-hover-state added disabledHover prop to buttons

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,14 +10,14 @@ import { titleCase } from '../../utils/stringFormatters';
 type HTMLAnchorProps = React.HTMLProps<HTMLAnchorElement>;
 
 export interface ButtonProps<C = any> extends MuiButtonProps {
-  /** 
-   * 
+  /**
+   *
    * This prop is only relevant for the `text` variant.
-   * 
+   *
    * The background type on which this Button is appears. Since we don't
    * currently support light vs dark mode on web as a theme variant, we can
    * use this prop to determine relevant styles.
-   * 
+   *
    * @default 'light'
    */
   bg?: BackgroundMode;
@@ -25,10 +25,10 @@ export interface ButtonProps<C = any> extends MuiButtonProps {
    * In order to use certain props that one would expect to have available on a button
    * while satisfying typescript in accordance with MUI's component 'composition'
    * rules, we have to do some forwardRef + generics shenanigans:
-   * 
+   *
    * https://mui.com/material-ui/guides/composition/#with-typescript
    * https://github.com/mui/material-ui/issues/15827#issuecomment-809209533
-   * 
+   *
    */
   component?: C | string;
   to?: LinkProps['to'];
@@ -53,16 +53,23 @@ export interface ButtonProps<C = any> extends MuiButtonProps {
    */
   loadingIndicator?: string;
   /**
-   * 
+   *
    * `text` buttons should have their content aligned to one side or the other, so that they
    * are aligned vertically along the same access as content around them. We achieve this using
    * negative margins. This prop lets us conditionally determine whether that alignment (and
    * on the left or right.
-   * 
+   *
    * @default undefined
    */
   align?: 'left' | 'right';
-};
+  /**
+   *
+   * prop to disable hover state of button.
+   *
+   * @default false
+   */
+  disableHover?: boolean;
+}
 
 const ButtonRoot = styled(MuiButton, {
   shouldForwardProp: (prop) => prop !== 'align',
@@ -79,13 +86,13 @@ const ButtonRoot = styled(MuiButton, {
   /**
    * We want our buttons to have padding: '12px 16px'; however, the root styles of the
    * MuiButton have padding: '6px 16px'. So we're doing some math here.
-   * 
+   *
    * https://github.com/mui/material-ui/blob/1b64a416d6eccc4423eb7749dc1fe12bfed64c1d/packages/mui-material/src/Button/Button.js#L81
    * */
   padding: '6px 16px',
   minHeight: 0,
   whiteSpace: 'nowrap',
-  /** 
+  /**
    * By default, a button width is dynamically set to fit its content.
    * If the width is less than 148px, the button width should be set to at least 148px wide.
    */
@@ -119,50 +126,58 @@ const ButtonRoot = styled(MuiButton, {
   }),
 }));
 
-const Button = React.forwardRef(<C extends React.ComponentType<any>>({
-  children,
-  onClick,
-  noStopPropagation,
-  loading = false,
-  loadingIndicator,
-  variant = 'primary',
-  disabled,
-  color = 'blue',
-  ...props
-}: ButtonProps<C>,
-  ref?: React.ForwardedRef<HTMLButtonElement>): JSX.Element => {
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
-    if (!noStopPropagation) {
-      event.stopPropagation();
-    }
-
-    if (onClick) {
-      onClick(event);
-    }
-  };
-
-  return (
-    <ButtonRoot
-      ref={ref}
-      color={color}
-      variant={variant}
-      onClick={handleClick}
-      disabled={disabled || loading}
-      endIcon={loading ?
-        <CircularProgress size={16} thickness={6} color="inherit" /> :
-        undefined
+const Button = React.forwardRef(
+  <C extends React.ComponentType<any>>(
+    {
+      children,
+      onClick,
+      noStopPropagation,
+      loading = false,
+      loadingIndicator,
+      variant = 'primary',
+      disabled,
+      color = 'blue',
+      disableHover,
+      ...props
+    }: ButtonProps<C>,
+    ref?: React.ForwardedRef<HTMLButtonElement>
+  ): JSX.Element => {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+      if (!noStopPropagation) {
+        event.stopPropagation();
       }
-      {...props}
-      css={undefined}
-    >
-      {typeof children === 'string' ?
-        <Typography variant="p1" weight="medium">
-          {loading ? loadingIndicator : titleCase(children)}
-        </Typography> :
-        children
+
+      if (onClick) {
+        onClick(event);
       }
-    </ButtonRoot>
-  );
-});
+    };
+
+    return (
+      <ButtonRoot
+        ref={ref}
+        color={color}
+        variant={variant}
+        onClick={handleClick}
+        disabled={disabled || loading}
+        endIcon={
+          loading ? (
+            <CircularProgress size={16} thickness={6} color="inherit" />
+          ) : undefined
+        }
+        disableHover={disableHover}
+        {...props}
+        css={undefined}
+      >
+        {typeof children === 'string' ? (
+          <Typography variant="p1" weight="medium">
+            {loading ? loadingIndicator : titleCase(children)}
+          </Typography>
+        ) : (
+          children
+        )}
+      </ButtonRoot>
+    );
+  }
+);
 
 export default Button;

--- a/src/components/Button/FilledButton.stories.mdx
+++ b/src/components/Button/FilledButton.stories.mdx
@@ -28,6 +28,12 @@ emphasis than a secondary button would give, such as "Next" in an onboarding flo
   <Story name="Disabled" args={{ children: "Disabled", disabled: true }}>
     {StoryTemplate.bind()}
   </Story>
+  <Story
+    name="Disabled Hover"
+    args={{ children: "Disabled Hover", disableHover: true }}
+  >
+    {StoryTemplate.bind()}
+  </Story>
 </Canvas>
 
 ### Colors

--- a/src/components/Button/PrimaryButton.stories.mdx
+++ b/src/components/Button/PrimaryButton.stories.mdx
@@ -27,6 +27,12 @@ Primary buttons have high emphasis and should be used for the primary, most impo
   <Story name="Disabled" args={{ children: "Disabled", disabled: true }}>
     {StoryTemplate.bind()}
   </Story>
+  <Story
+    name="Disabled Hover"
+    args={{ children: "Disabled Hover", disableHover: true }}
+  >
+    {StoryTemplate.bind()}
+  </Story>
 </Canvas>
 
 ### Colors

--- a/src/components/Button/SecondaryButton.stories.mdx
+++ b/src/components/Button/SecondaryButton.stories.mdx
@@ -23,6 +23,12 @@ alternative, secondary action.
   <Story name="Disabled" args={{ children: "Disabled", disabled: true }}>
     {StoryTemplate.bind()}
   </Story>
+  <Story
+    name="Disabled Hover"
+    args={{ children: "Disabled Hover", disableHover: true }}
+  >
+    {StoryTemplate.bind()}
+  </Story>
 </Canvas>
 
 <br />

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -93,8 +93,8 @@ const izakayaCustomOptions = {
 };
 
 /**
-* @DEPRECATED -- component overrides within izakaya; merged with what is provided by hajimari
-* */
+ * @DEPRECATED -- component overrides within izakaya; merged with what is provided by hajimari
+ * */
 export const izakayaComponentOverrides: ThemeOptions['components'] = {
   MuiInputBase: {
     styleOverrides: {
@@ -329,16 +329,17 @@ export const componentOverrides: ThemeOptions['components'] = {
            * If a color that is not "default" is passed in, we
            * can use the 500 shade of that color for the icon
            */
-          ...(color !== 'default' && color !== 'inherit' && {
-            color: theme.palette[color][500],
-          }),
+          ...(color !== 'default' &&
+            color !== 'inherit' && {
+              color: theme.palette[color][500],
+            }),
           /**
-          * The background color of an IconButton on hover is generally
-          * the lightest shade of the chosen color. Rather than trying to do
-          * any "clever" code-golfing, we're being intentionally verbose so it's
-          * very obvious what each color does on hover, particularly since there
-          * are a few exceptions to the general shade rule of 100.
-          * */
+           * The background color of an IconButton on hover is generally
+           * the lightest shade of the chosen color. Rather than trying to do
+           * any "clever" code-golfing, we're being intentionally verbose so it's
+           * very obvious what each color does on hover, particularly since there
+           * are a few exceptions to the general shade rule of 100.
+           * */
           '&:hover, &.Mui-focusVisible': {
             ...(color === 'inherit' && {
               backgroundColor: 'inherit',
@@ -365,37 +366,35 @@ export const componentOverrides: ThemeOptions['components'] = {
   },
   MuiButton: {
     styleOverrides: {
-      text: ({ ownerState, theme }) => (
-        {
-          ...(ownerState.color != null && {
-            color: theme.palette[ownerState.color][500],
+      text: ({ ownerState, theme }) => ({
+        ...(ownerState.color != null && {
+          color: theme.palette[ownerState.color][500],
+          '&:hover': {
+            backgroundColor: theme.palette[ownerState.color][100],
+          },
+          '&:disabled': {
+            color: theme.palette.greyscale[700],
+          },
+          /**
+           * styles applied only for 'text'variant = 'text' when bg (background mode) = 'dark'
+           * */
+          ...(ownerState.bg === 'dark' && {
+            color: theme.palette[ownerState.color][300],
+            /**
+             * On dark backgrounds, the hover background color for every color
+             * that isn't "default" will be the 300 shade value at 10% opacity.
+             * (Note the "10" as the alpha to extend the hex color)
+             *
+             */
             '&:hover': {
-              backgroundColor: theme.palette[ownerState.color][100],
+              backgroundColor: `${theme.palette[ownerState.color][300]}10`,
             },
             '&:disabled': {
-              color: theme.palette.greyscale[700],
+              color: theme.palette.greyscale[900],
             },
-            /**
-             * styles applied only for 'text'variant = 'text' when bg (background mode) = 'dark'
-             * */
-            ...(ownerState.bg === 'dark' && {
-              color: theme.palette[ownerState.color][300],
-              /**
-               * On dark backgrounds, the hover background color for every color
-               * that isn't "default" will be the 300 shade value at 10% opacity.
-               * (Note the "10" as the alpha to extend the hex color)
-               * 
-              */
-              '&:hover': {
-                backgroundColor: `${theme.palette[ownerState.color][300]}10`,
-              },
-              '&:disabled': {
-                color: theme.palette.greyscale[900],
-              },
-            }),
-          })
-        }
-      ),
+          }),
+        }),
+      }),
       disabled: ({ ownerState, theme }) => ({
         borderRadius: 8,
         padding: '12px 16px',
@@ -414,17 +413,20 @@ export const componentOverrides: ThemeOptions['components'] = {
         }),
       }),
       primary: ({ ownerState, theme }) => {
-        const background = ownerState.color && theme.palette[ownerState.color][500];
+        const background =
+          ownerState.color && theme.palette[ownerState.color][500];
         return {
           /**
            * the default background color for a primary button is the 500 shade
-          */
+           */
           ...(ownerState.color != null && {
             color: background && theme.palette.getContrastText(background),
             backgroundColor: background,
             /** the hover color is the 700 shade for primary buttons */
             '&:hover': {
-              backgroundColor: theme.palette[ownerState.color][700],
+              backgroundColor: ownerState.disableHover
+                ? background
+                : theme.palette[ownerState.color][700],
             },
           }),
         };
@@ -437,7 +439,9 @@ export const componentOverrides: ThemeOptions['components'] = {
           color: theme.palette[ownerState.color][500],
           /** the hover color is the 100 value for secondary buttons */
           '&:hover': {
-            backgroundColor: theme.palette[ownerState.color][100],
+            backgroundColor: ownerState.disableHover
+              ? 'transparent'
+              : theme.palette[ownerState.color][100],
           },
         }),
       }),
@@ -447,7 +451,9 @@ export const componentOverrides: ThemeOptions['components'] = {
           color: theme.palette[ownerState.color][500],
           /** the hover color is the 700 value for primary buttons */
           '&:hover': {
-            backgroundColor: theme.palette[ownerState.color][300],
+            backgroundColor: ownerState.disableHover
+              ? theme.palette[ownerState.color][100]
+              : theme.palette[ownerState.color][300],
           },
         }),
         /** greyscale has slightly different hues */
@@ -459,7 +465,7 @@ export const componentOverrides: ThemeOptions['components'] = {
           },
         }),
       }),
-    }
+    },
   },
 };
 
@@ -614,5 +620,3 @@ export const themeOptions: ThemeOptions = {
 const theme = createTheme(themeOptions);
 
 export default theme;
-
-


### PR DESCRIPTION
### Description
On mobile hover state can be activated when scrolling over element.  This PR proposes adding a `disableHover` prop so that we can disable when desired on mobile.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/24616134/187542571-4abc5fac-d3c4-47d1-8c86-f7527e469b59.png">
