### PR TITLE
`Dialog` (and friends) updates + fixes

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -247,8 +247,9 @@ interface DialogContentProps extends DialogContentProps$1 {
 declare const DialogContent: ({ children, ...otherProps }: DialogContentProps) => JSX.Element;
 
 interface DialogHeaderProps extends DialogTitleProps {
+    divider?: boolean;
 }
-declare const DialogHeader: ({ children, ...props }: DialogHeaderProps) => JSX.Element;
+declare const DialogHeader: ({ children, divider, ...props }: DialogHeaderProps) => JSX.Element;
 
 interface DialogTopContentProps extends DialogTitleProps {
     showCloseButton: boolean;

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -222,11 +222,25 @@ declare const DatePickerField: ({ name, label, helperText, textFieldProps, onCha
 
 interface DialogProps extends DialogProps$2 {
 }
-declare const Dialog: ({ children, sx, ...props }: DialogProps) => JSX.Element;
+declare const Dialog: ({ fullWidth, maxWidth, children, ...props }: DialogProps) => JSX.Element;
 
 interface DialogActionProps extends DialogActionsProps {
+    /**
+     * callback for the primary action that is hooked up to a `Button`
+     * with `primary` variant and `blue` color.
+     */
+    primaryAction?: (arg?: any) => void;
+    /** label/CTA for the `Button` that calls `primaryAction` */
+    primaryCta?: React$1.ReactNode;
+    /**
+     * callback for the primary action that is hooked up to a `Button`
+     * with `text` variant and `blue` color.
+     */
+    secondaryAction?: (arg?: any) => void;
+    /** label/CTA for the `Button` that calls `secondaryAction` */
+    secondaryCta?: React$1.ReactNode;
 }
-declare const DialogActions: ({ children, sx, ...otherProps }: DialogActionProps) => JSX.Element;
+declare const DialogActions: ({ primaryAction, primaryCta, secondaryAction, secondaryCta, children, ...otherProps }: DialogActionProps) => JSX.Element;
 
 interface DialogContentProps extends DialogContentProps$1 {
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hajimari",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hajimari",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hajimari",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Hearth's design system + component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/Dialog/Dialog.stories.mdx
+++ b/src/components/Dialog/Dialog.stories.mdx
@@ -18,7 +18,7 @@ A dialog is a basic component to be used across the product.
 It can be composed of `DialogHeader`, `DialogTopContent` and `DialogActions`.
 
 <Canvas>
-  <Story story={dialog} name="Playground" />
+  <Story story={dialog} name="Sandbox" />
 </Canvas>
 
-<ArgsTable of={Dialog} story="Playground" />
+<ArgsTable of={Dialog} story="Sandbox" />

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -1,15 +1,14 @@
-import React, { useState } from 'react';
-import { ComponentMeta, Story } from '@storybook/react';
-import { withDesign } from 'storybook-addon-designs';
-import { ArgType } from '@storybook/components';
+import React, { useState } from "react";
+import { ComponentMeta, Story } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import { ArgType } from "@storybook/components";
 
-import Button from '../Button';
-import Dialog, { DialogProps } from './Dialog';
-import DialogContent from '../DialogContentText';
-import DialogHeader from '../DialogHeader';
-import DialogTopContent from '../DialogTopContent';
-import DialogActions from '../DialogActions';
-import ConfirmationModal from '../ConfirmationModal/ConfirmationModal';
+import Button from "../Button";
+import Dialog, { DialogProps } from "./Dialog";
+import DialogContent from "../DialogContentText";
+import DialogHeader from "../DialogHeader";
+import DialogTopContent from "../DialogTopContent";
+import DialogActions from "../DialogActions";
 
 export const argTypes = {
   open: {
@@ -92,7 +91,9 @@ type TemplateArgs = {
   header?: ArgType;
   content?: ArgType;
   maxWidth?: ArgType;
-  showCloseButton?: ArgType;
+  showCloseButton?: boolean;
+  actions: ArgType;
+  title?: ArgType;
 } & DialogProps;
 
 export default {
@@ -113,7 +114,7 @@ const DialogTemplate = ({
   backlink,
   maxWidth,
   actions,
-  showCloseButton,
+  showCloseButton = false,
   ...args
 }: TemplateArgs): JSX.Element => {
   const [showDialog, setShowDialog] = useState(false);
@@ -123,7 +124,7 @@ const DialogTemplate = ({
 
   return (
     <>
-      <Button onClick={() => setShowDialog(true)} variant='outlined'>
+      <Button onClick={() => setShowDialog(true)} variant="outlined">
         Open Dialog
       </Button>
       <Dialog
@@ -137,7 +138,12 @@ const DialogTemplate = ({
         />
         {header && <DialogHeader>{header}</DialogHeader>}
         {content && <DialogContent>{content}</DialogContent>}
-        {actions && <DialogActions>{actions}</DialogActions>}
+        <DialogActions
+          primaryAction={() => {}}
+          primaryCta="Delete"
+          secondaryAction={() => {}}
+          secondaryCta="Cancel"
+        />
       </Dialog>
     </>
   );

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -136,7 +136,7 @@ const DialogTemplate = ({
           backlink={backlink}
           showCloseButton={showCloseButton}
         />
-        {header && <DialogHeader>{header}</DialogHeader>}
+        {header && <DialogHeader divider>{header}</DialogHeader>}
         {content && <DialogContent>{content}</DialogContent>}
         <DialogActions
           primaryAction={() => {}}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,23 +1,13 @@
-import React from 'react';
-import MuiDialog, { DialogProps as MuiDialogProps } from '@mui/material/Dialog';
-
-import styled from '../../theme/styled';
+import React from "react";
+import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
 
 export interface DialogProps extends MuiDialogProps { }
 
-const DialogRoot = styled(MuiDialog)(() => ({
-  border: 'inherit',
-  borderRadius: '16px',
-}));
-
 const Dialog = ({
+  fullWidth,
+  maxWidth,
   children,
-  sx,
   ...props
-}: DialogProps): JSX.Element => (
-  <DialogRoot {...props}>
-    {children}
-  </DialogRoot>
-);
+}: DialogProps): JSX.Element => <MuiDialog {...props}>{children}</MuiDialog>;
 
 export default Dialog;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
+import React from 'react';
+import MuiDialog, { DialogProps as MuiDialogProps } from '@mui/material/Dialog';
 
 export interface DialogProps extends MuiDialogProps { }
 

--- a/src/components/DialogActions/DialogActions.tsx
+++ b/src/components/DialogActions/DialogActions.tsx
@@ -1,27 +1,90 @@
-import React from "react";
-import { DialogActions as MuiDialogActions } from "@mui/material";
-import { DialogActionsProps as MuiDialogActionsProps } from "@mui/material";
+import React from 'react';
+import {
+  DialogActions as MuiDialogActions,
+  DialogActionsProps as MuiDialogActionsProps,
+  Theme,
+} from '@mui/material';
+import { experimental_sx as e_sx } from '@mui/system';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import styled from '../../theme/styled';
+import Button from '../Button';
+import Box from '../Box';
 
-export interface DialogActionProps extends MuiDialogActionsProps { }
+export interface DialogActionProps extends MuiDialogActionsProps {
+  /**
+   * callback for the primary action that is hooked up to a `Button`
+   * with `primary` variant and `blue` color.
+   */
+  primaryAction?: (arg?: any) => void;
+  /** label/CTA for the `Button` that calls `primaryAction` */
+  primaryCta?: React.ReactNode;
+  /**
+   * callback for the primary action that is hooked up to a `Button`
+   * with `text` variant and `blue` color.
+   */
+  secondaryAction?: (arg?: any) => void;
+  /** label/CTA for the `Button` that calls `secondaryAction` */
+  secondaryCta?: React.ReactNode;
+}
 
-const DialogActionsRoot = styled(MuiDialogActions)(() => ({
-  border: 'inherit',
-  borderRadius: '16px',
-  display: 'flex',
-  px: 3,
-  pb: 2,
-}));
+const DialogActionsRoot = styled(MuiDialogActions)(
+  e_sx({
+    border: 'inherit',
+    borderRadius: '16px',
+    display: 'flex',
+    px: 3,
+    pb: 3,
+    maxWidth: '100%',
+    flex: 1,
+  })
+);
 
 const DialogActions = ({
+  primaryAction,
+  primaryCta,
+  secondaryAction,
+  secondaryCta,
   children,
-  sx,
   ...otherProps
-}: DialogActionProps): JSX.Element => (
-  <DialogActionsRoot {...otherProps}>
-    {children}
-  </DialogActionsRoot>
-);
+}: DialogActionProps): JSX.Element => {
+  const isMobile = useMediaQuery((t: Theme) => t.breakpoints.down('md'));
+
+  return (
+    <DialogActionsRoot {...otherProps}>
+      {children}
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap-reverse',
+          alignItems: 'center',
+          width: { xs: '100%', sm: 'unset' },
+        }}
+      >
+        {secondaryAction && secondaryCta && (
+          <Button
+            variant="text"
+            onClick={secondaryAction}
+            fullWidth={isMobile}
+            sx={{ mr: { xs: 'unset', sm: 1 } }}
+          >
+            {secondaryCta}
+          </Button>
+        )}
+        {primaryAction && primaryCta && (
+          <Button
+            variant="primary"
+            color="blue"
+            onClick={primaryAction}
+            fullWidth={isMobile}
+            sx={{ mb: { xs: 1, sm: 'unset' } }}
+          >
+            {primaryCta}
+          </Button>
+        )}
+      </Box>
+    </DialogActionsRoot>
+  );
+};
 
 export default DialogActions;

--- a/src/components/DialogActions/DialogActions.tsx
+++ b/src/components/DialogActions/DialogActions.tsx
@@ -48,7 +48,7 @@ const DialogActions = ({
   children,
   ...otherProps
 }: DialogActionProps): JSX.Element => {
-  const isMobile = useMediaQuery((t: Theme) => t.breakpoints.down('md'));
+  const isMobile = useMediaQuery((t: Theme) => t.breakpoints.down('sm'));
 
   return (
     <DialogActionsRoot {...otherProps}>

--- a/src/components/DialogHeader/DialogHeader.tsx
+++ b/src/components/DialogHeader/DialogHeader.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import MuiDialogHeader, {
   DialogTitleProps as MuiDialogHeaderProps
 } from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
 
 import styled from '../../theme/styled';
 
-export interface DialogHeaderProps extends MuiDialogHeaderProps { }
+export interface DialogHeaderProps extends MuiDialogHeaderProps {
+  divider?: boolean;
+}
 
 const DialogHeaderRoot = styled(MuiDialogHeader)(() => ({
   backgroundColor: 'inherit',
@@ -14,11 +17,15 @@ const DialogHeaderRoot = styled(MuiDialogHeader)(() => ({
 
 const DialogHeader = ({
   children,
+  divider = false,
   ...props
 }: DialogHeaderProps): JSX.Element => (
-  <DialogHeaderRoot {...props}>
-    {children}
-  </DialogHeaderRoot>
+  <>
+    {divider && <Divider light variant="fullWidth" sx={{ mx: -3, mb: 1 }} />}
+    <DialogHeaderRoot {...props}>
+      {children}
+    </DialogHeaderRoot>
+  </>
 );
 
 export default DialogHeader;

--- a/src/components/DialogTopContent/DialogTopContent.tsx
+++ b/src/components/DialogTopContent/DialogTopContent.tsx
@@ -1,13 +1,13 @@
-import React from "react";
+import React from 'react';
 import MuiDialogTopContent, {
   DialogTitleProps as MuiDialogTopContentProps,
-} from "@mui/material/DialogTitle";
-import { IconButton } from "@mui/material";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import CloseIcon from "@mui/icons-material/Close";
+} from '@mui/material/DialogTitle';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
 
 import styled from '../../theme/styled';
-import Button from "../Button";
+import Button from '../Button';
+import IconButton from '../IconButton';
 
 export interface DialogTopContentProps extends MuiDialogTopContentProps {
   showCloseButton: boolean;
@@ -33,14 +33,7 @@ const DialogTopContent = ({
 }: DialogTopContentProps): JSX.Element => (
   <DialogTopContentRoot {...props}>
     {backlink && (
-      <Button
-        variant="text"
-        sx={{
-          maxWidth: "10%",
-          m: 0,
-        }}
-        onClick={backlinkAction}
-      >
+      <Button variant="text" sx={{ m: 0 }} onClick={backlinkAction}>
         <ArrowBackIcon sx={{ mr: 2 }} />
         {backlink}
       </Button>

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -302,6 +302,19 @@ export const componentOverrides: ThemeOptions['components'] = {
       },
     },
   },
+  MuiDialog: {
+    styleOverrides: {
+      root: { padding: '24px' },
+      paper: {
+        borderRadius: 8,
+        boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.08);',
+        minWidth: '280px',
+        minHeight: '180px',
+        maxWidth: '680px',
+        width: '100%',
+      },
+    },
+  },
   MuiDivider: {
     styleOverrides: {
       root: {


### PR DESCRIPTION
#### Description:
**_Closing #46 in favor of this PR._**

So the original implementation of the `Dialog` component here didn't quite...work correctly and wasn't styled quite right. Long ago @eynglv started to make fixes during a previous project involving the `Dialog` component, but we put a pause on it in favor of just using the base MUI component and coming back to this later (because time, scope creep, etc). 

As a part of the [leads management/RFQ project](https://www.figma.com/file/one84Qz38iRIOzinc8gVDy/Lead-Request-Form?node-id=0%3A1&t=paI0SUoN1EnoKrPq-1), I figured it would be worth the investment to finish up the fixes to avoid further tech debt. (The plan is to use this component in the "add new lead" and "lead detail view" modals, and later update others across the code base)

The only caveat is that I didn't "fix" anything in the `stories` files because that would be even _more_ scope creep that I don't think is valuable at the moment. A ticket will be added to the backlog to address this 😅 

<img width="1552" alt="Screen Shot 2022-11-23 at 4 30 57 PM" src="https://user-images.githubusercontent.com/9397381/203668651-04fe4b52-c5af-474d-a2fa-a95af28c94b6.png">
<img width="1552" alt="Screen Shot 2022-11-23 at 4 30 43 PM" src="https://user-images.githubusercontent.com/9397381/203668659-d359493f-39b3-4b72-a200-cf66250be66c.png">

