### PR TITLE
Make ListItem accept react nodes

### DIFF
--- a/src/components/ListItem/ListItem.stories.mdx
+++ b/src/components/ListItem/ListItem.stories.mdx
@@ -5,6 +5,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ListItem from './ListItem';
 import Button from '../Button';
 import Box from '../Box';
+import Typography from '../Typography';
 
 export const argTypes = {
   headerText: {
@@ -88,6 +89,33 @@ the list item is separated if it is followed by a sibling element.
 
 <Canvas>
   <Story name='Sandbox' args={{ headerText: 'some text!' }}>
+    {ListItemTemplate.bind({})}
+  </Story>
+</Canvas>
+
+#### With Links:
+
+<Canvas>
+  <Story
+    name='With Links'
+    args={{
+      headerText: (
+        <Typography>
+          <a href={'/?path=/docs/organism-list-listitem--sandbox#list-item'}>
+            An example link
+          </a>
+        </Typography>
+      ),
+      description: (
+        <Typography>
+          we might want to add text{' '}
+          <a href={'/?path=/docs/organism-list-listitem--sandbox#list-item'}>
+            with a link
+          </a>
+        </Typography>
+      ),
+    }}
+  >
     {ListItemTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -13,12 +13,12 @@ export interface ListItemProps extends MuiListItemProps {
    * @default undefined
    * @optional
    */
-  headerText?: string;
+  headerText?: React.ReactNode;
   /**
    * a sorta subheader or more text to supplement main header
    * @optional
    */
-  description?: string;
+  description?: React.ReactNode;
   /**
    * primary actions are passed in as children. current use cases include button, toggle, and expand.
    * if no children is passed in, list item will display text row.


### PR DESCRIPTION
I needed to modify the type so that I could add a link to the bulk help page which was added in [this PR](https://github.com/shogun-hearth/komorebi/pull/114). I should have done this when I created these components 😓 but what can i say I clowned myself 🤡 
![Screenshot 2023-06-06 at 3 24 05 PM](https://github.com/shogun-hearth/hajimari/assets/73679611/1311d944-eea9-4ccb-8403-03afac70d158)
